### PR TITLE
feat: login with a principal and anonymous identity

### DIFF
--- a/frontend/const.ts
+++ b/frontend/const.ts
@@ -52,10 +52,10 @@ export type AccountDefault = z.infer<typeof AccountDefaultEnum>;
 export const WorkerTaskEnum = z.enum(["TRANSACTIONS", "ASSETS"]);
 export type WorkerTask = z.infer<typeof WorkerTaskEnum>;
 
-export const AuthNetworkNameEnum = z.enum(["Internet Identity", "NFID", "Metamask", "Seed", "NONE"]);
+export const AuthNetworkNameEnum = z.enum(["Internet Identity", "NFID", "Metamask", "Seed", "Watch-Only", "NONE"]);
 export type AuthNetworkName = z.infer<typeof AuthNetworkNameEnum>;
 
-export const AuthNetworkTypeEnum = z.enum(["IC", "NFID", "MM", "NONE"]);
+export const AuthNetworkTypeEnum = z.enum(["IC", "NFID", "MM", "S", "WO", "NONE"]);
 export type AuthNetworkType = z.infer<typeof AuthNetworkTypeEnum>;
 
 export const DeleteContactTypeEnum = z.enum(["CONTACT", "ASSET", "SUB"]);

--- a/frontend/pages/components/topbar/index.tsx
+++ b/frontend/pages/components/topbar/index.tsx
@@ -62,13 +62,13 @@ const TopBarComponent = () => {
               }`}
               onClick={handleReloadButton}
             />
-            {watchOnlyMode && <p className="opacity-50">Watch-Only Mode</p>}
+            {watchOnlyMode && <p className="opacity-50">{t("watchOnlyMode.title")}</p>}
           </div>
         </div>
         <div className="flex flex-row justify-start items-center pr-9 gap-9">
           <div className="flex flex-row justify-start items-center gap-2 text-md">
             <WalletIcon className="fill-SvgColor dark:fill-SvgColor max-w-[1.5rem] h-auto"></WalletIcon>
-            <p className="opacity-70">Total Balance:</p>
+            <p className="opacity-70">{t("total.balance")}:</p>
             <p className="font-medium">{`$${getTotalAmountInCurrency().toFixed(2)}`}</p>
             <p className="opacity-70">USD</p>
           </div>

--- a/frontend/pages/components/topbar/index.tsx
+++ b/frontend/pages/components/topbar/index.tsx
@@ -25,11 +25,12 @@ import ThemeModal from "./themeModal";
 import { ThemesEnum } from "@/const";
 import { CustomCopy } from "@components/CopyTooltip";
 import { AssetHook } from "@pages/home/hooks/assetHook";
+import { useAppSelector } from "@redux/Store";
 
 const TopBarComponent = () => {
   const { t } = useTranslation();
   const { onLanguageChange } = LanguageHook();
-
+  const { watchOnlyMode } = useAppSelector((state) => state.auth);
   const { theme, themeOpen, setThemeOpen } = ThemeHook();
   const { authClient } = AccountHook();
   const { getTotalAmountInCurrency, reloadBallance, assetLoading } = AssetHook();
@@ -61,6 +62,7 @@ const TopBarComponent = () => {
               }`}
               onClick={handleReloadButton}
             />
+            {watchOnlyMode && <p className="opacity-50">Watch-Only Mode</p>}
           </div>
         </div>
         <div className="flex flex-row justify-start items-center pr-9 gap-9">

--- a/frontend/pages/home/components/ICRC/detail/SubaccountAction.tsx
+++ b/frontend/pages/home/components/ICRC/detail/SubaccountAction.tsx
@@ -9,6 +9,7 @@ import { GeneralHook } from "@pages/home/hooks/generalHook";
 import { FC, Fragment } from "react";
 import { useTranslation } from "react-i18next";
 import { useAppSelector } from "@redux/Store";
+import { clsx } from "clsx";
 
 interface ICRCSubaccountActionProps {
   onActionClick(value: DrawerOption): void;
@@ -36,12 +37,16 @@ const ICRCSubaccountAction: FC<ICRCSubaccountActionProps> = ({ onActionClick }) 
       </div>
       <div className="flex flex-row justify-around items-center h-full w-[calc(100%-17rem)] text-ThirdTextColorLight dark:text-ThirdTextColor">
         <div
-          className={`flex flex-col justify-center items-center w-1/3 gap-1 ${watchOnlyMode && "pointer-events-none"}`}
+          className={clsx(
+            "flex flex-col justify-center items-center w-1/3 gap-1",
+            watchOnlyMode && "pointer-events-none",
+          )}
         >
           <div
-            className={`flex flex-row justify-center items-center w-7 h-7 rounded-md cursor-pointer ${
-              (watchOnlyMode && "bg-GrayColor") || "bg-SelectRowColor"
-            }`}
+            className={clsx(
+              "flex flex-row justify-center items-center w-7 h-7 rounded-md cursor-pointer",
+              (watchOnlyMode && "bg-GrayColor") || "bg-SelectRowColor",
+            )}
             onClick={() => {
               onActionClick(DrawerOptionEnum.Enum.SEND);
             }}

--- a/frontend/pages/home/components/ICRC/detail/SubaccountAction.tsx
+++ b/frontend/pages/home/components/ICRC/detail/SubaccountAction.tsx
@@ -8,12 +8,15 @@ import { toFullDecimal } from "@/utils";
 import { GeneralHook } from "@pages/home/hooks/generalHook";
 import { FC, Fragment } from "react";
 import { useTranslation } from "react-i18next";
+import { useAppSelector } from "@redux/Store";
+
 interface ICRCSubaccountActionProps {
   onActionClick(value: DrawerOption): void;
 }
 
 const ICRCSubaccountAction: FC<ICRCSubaccountActionProps> = ({ onActionClick }) => {
   const { getAssetIcon, selectedAsset, selectedAccount } = GeneralHook();
+  const { watchOnlyMode } = useAppSelector((state) => state.auth);
   const { t } = useTranslation();
 
   return (
@@ -32,9 +35,13 @@ const ICRCSubaccountAction: FC<ICRCSubaccountActionProps> = ({ onActionClick }) 
         </div>
       </div>
       <div className="flex flex-row justify-around items-center h-full w-[calc(100%-17rem)] text-ThirdTextColorLight dark:text-ThirdTextColor">
-        <div className="flex flex-col justify-center items-center w-1/3 gap-1">
+        <div
+          className={`flex flex-col justify-center items-center w-1/3 gap-1 ${watchOnlyMode && "pointer-events-none"}`}
+        >
           <div
-            className="flex flex-row justify-center items-center w-7 h-7 bg-SelectRowColor rounded-md cursor-pointer"
+            className={`flex flex-row justify-center items-center w-7 h-7 rounded-md cursor-pointer ${
+              (watchOnlyMode && "bg-GrayColor") || "bg-SelectRowColor"
+            }`}
             onClick={() => {
               onActionClick(DrawerOptionEnum.Enum.SEND);
             }}

--- a/frontend/pages/home/components/ICRC/detail/subaccountTableInfo.tsx
+++ b/frontend/pages/home/components/ICRC/detail/subaccountTableInfo.tsx
@@ -15,6 +15,7 @@ export default function ICRCSubInfo({ subInfoType, setSubInfoType, children }: I
   const { t } = useTranslation();
 
   const { transactions } = useAppSelector((state) => state.asset);
+  const { watchOnlyMode } = useAppSelector((state) => state.auth);
   const { allowances } = useAllowances();
   const transactionsCount = useMemo(() => transactions.length, [transactions]);
   const allowancesCount = useMemo(() => allowances.length, [allowances]);
@@ -52,7 +53,7 @@ export default function ICRCSubInfo({ subInfoType, setSubInfoType, children }: I
             </p>
           </CustomButton>
         </div>
-        {subInfoType === ICRCSubaccountInfoEnum.Enum.ALLOWANCES && <AddAllowanceButton />}
+        {!watchOnlyMode && subInfoType === ICRCSubaccountInfoEnum.Enum.ALLOWANCES && <AddAllowanceButton />}
       </div>
 
       <div className="flex w-full">{children}</div>

--- a/frontend/pages/hooks/accountHook.tsx
+++ b/frontend/pages/hooks/accountHook.tsx
@@ -5,7 +5,7 @@ export const AccountHook = () => {
   const dispatch = useAppDispatch();
   const { authClient, userAgent } = useAppSelector((state) => state.auth);
   const setAuthClient = (authClient: string) => {
-    dispatch(setAuthenticated(true, false, authClient.toLowerCase()));
+    dispatch(setAuthenticated(true, false, false, authClient.toLowerCase()));
   };
   return { authClient, setAuthClient, userAgent };
 };

--- a/frontend/pages/login/hooks/loginhook.tsx
+++ b/frontend/pages/login/hooks/loginhook.tsx
@@ -1,8 +1,8 @@
 // svgs
-import XxxxIcon from "../../../assets/svg/files/xxxx-logo.svg";
-import icUrl from "../../../assets/img/icp-logo.png";
-import nfidUrl from "../../../assets/img/nfid-logo.png";
-import metamaskUrl from "../../../assets/img/metamask-logo.png";
+import XxxxIcon from "@/assets/svg/files/xxxx-logo.svg";
+import icUrl from "@/assets/img/icp-logo.png";
+import nfidUrl from "@/assets/img/nfid-logo.png";
+import metamaskUrl from "@/assets/img/metamask-logo.png";
 //
 import { useState } from "react";
 import { AuthNetworkNameEnum, AuthNetworkTypeEnum } from "@/const";
@@ -33,16 +33,36 @@ export const LoginHook = () => {
       name: AuthNetworkNameEnum.Values.Seed,
       extra: "devs.only",
       icon: <img className={""} src={XxxxIcon} alt="" />,
-      type: AuthNetworkTypeEnum.Values.NONE,
+      type: AuthNetworkTypeEnum.Values.S,
+      network: "",
+    },
+    {
+      name: AuthNetworkNameEnum.Values["Watch-Only"],
+      icon: <img className={""} src={XxxxIcon} alt="" />,
+      type: AuthNetworkTypeEnum.Values.WO,
       network: "",
     },
   ];
   const [open, setOpen] = useState(false);
   const [seedOpen, setSeedOpen] = useState(false);
   const [seed, setSeed] = useState("");
+  const [watchOnlyOpen, setWatchOnlyOpen] = useState(false);
+  const [principalAddress, setPrincipalAddress] = useState("");
   const handleOpenChange = (value: boolean) => {
     setOpen(value);
   };
 
-  return { handleOpenChange, loginOpts, open, seedOpen, setSeedOpen, seed, setSeed };
+  return {
+    handleOpenChange,
+    loginOpts,
+    open,
+    seedOpen,
+    setSeedOpen,
+    seed,
+    setSeed,
+    watchOnlyOpen,
+    setWatchOnlyOpen,
+    principalAddress,
+    setPrincipalAddress,
+  };
 };

--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -9,11 +9,12 @@ import { LoginHook } from "./hooks/loginhook";
 import FlagSelector from "./components/flagSelector";
 import { useTranslation } from "react-i18next";
 import { ThemeHook } from "@hooks/themeHook";
-import { ChangeEvent, Fragment } from "react";
+import { ChangeEvent, Fragment, useState } from "react";
 import { handleAuthenticated, handleSeedAuthenticated, handlePrincipalAuthenticated } from "@/redux/CheckAuth";
 import { AuthNetworkTypeEnum, ThemesEnum } from "@/const";
 import { AuthNetwork } from "@redux/models/TokenModels";
 import { CustomInput } from "@components/Input";
+import { decodeIcrcAccount } from "@dfinity/ledger";
 
 const Login = () => {
   const { t } = useTranslation();
@@ -31,6 +32,8 @@ const Login = () => {
     setPrincipalAddress,
   } = LoginHook();
   const { theme } = ThemeHook();
+  const [watchOnlyLoginErr, setWatchOnlyLoginErr] = useState(false);
+
   return (
     <Fragment>
       <div className="flex flex-row w-full h-full bg-PrimaryColorLight dark:bg-PrimaryColor">
@@ -101,7 +104,17 @@ const Login = () => {
                         compOutClass=""
                         value={principalAddress}
                         onChange={onPrincipalChange}
+                        border={watchOnlyLoginErr ? "error" : undefined}
                         autoFocus
+                        sufix={
+                          <CheckIcon
+                            className={`w-4 h-4 ${
+                              principalAddress.length > 0 && !watchOnlyLoginErr
+                                ? "stroke-BorderSuccessColor"
+                                : "stroke-PrimaryTextColorLight dark:stroke-PrimaryTextColor"
+                            } opacity-50 mr-2`}
+                          />
+                        }
                         onKeyDown={(e) => {
                           if (e.key === "Enter") handlePrincipalAuthenticated(principalAddress);
                         }}
@@ -156,6 +169,12 @@ const Login = () => {
   }
   function onPrincipalChange(e: ChangeEvent<HTMLInputElement>) {
     setPrincipalAddress(e.target.value);
+    try {
+      decodeIcrcAccount(e.target.value);
+      setWatchOnlyLoginErr(false);
+    } catch {
+      setWatchOnlyLoginErr(true);
+    }
   }
 };
 

--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -10,14 +10,26 @@ import FlagSelector from "./components/flagSelector";
 import { useTranslation } from "react-i18next";
 import { ThemeHook } from "@hooks/themeHook";
 import { ChangeEvent, Fragment } from "react";
-import { handleAuthenticated, handleSeedAuthenticated } from "@/redux/CheckAuth";
+import { handleAuthenticated, handleSeedAuthenticated, handlePrincipalAuthenticated } from "@/redux/CheckAuth";
 import { AuthNetworkTypeEnum, ThemesEnum } from "@/const";
 import { AuthNetwork } from "@redux/models/TokenModels";
 import { CustomInput } from "@components/Input";
 
 const Login = () => {
   const { t } = useTranslation();
-  const { handleOpenChange, loginOpts, open, seedOpen, setSeedOpen, seed, setSeed } = LoginHook();
+  const {
+    handleOpenChange,
+    loginOpts,
+    open,
+    seedOpen,
+    setSeedOpen,
+    seed,
+    setSeed,
+    watchOnlyOpen,
+    setWatchOnlyOpen,
+    principalAddress,
+    setPrincipalAddress,
+  } = LoginHook();
   const { theme } = ThemeHook();
   return (
     <Fragment>
@@ -54,7 +66,7 @@ const Login = () => {
                       </h3>
                       {opt.icon}
                     </div>
-                    {seedOpen && opt.type === AuthNetworkTypeEnum.Enum.NONE && (
+                    {seedOpen && opt.type === AuthNetworkTypeEnum.Enum.S && (
                       <CustomInput
                         sizeInput={"medium"}
                         intent={"secondary"}
@@ -79,6 +91,19 @@ const Login = () => {
                         }
                         onKeyDown={(e) => {
                           if (e.key === "Enter") handleSeedAuthenticated(seed);
+                        }}
+                      />
+                    )}
+                    {watchOnlyOpen && opt.type === AuthNetworkTypeEnum.Enum.WO && (
+                      <CustomInput
+                        sizeInput={"medium"}
+                        intent={"secondary"}
+                        compOutClass=""
+                        value={principalAddress}
+                        onChange={onPrincipalChange}
+                        autoFocus
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") handlePrincipalAuthenticated(principalAddress);
                         }}
                       />
                     )}
@@ -115,15 +140,22 @@ const Login = () => {
   async function handleLogin(opt: AuthNetwork) {
     if (opt.type === AuthNetworkTypeEnum.Values.IC || opt.type === AuthNetworkTypeEnum.Values.NFID) {
       setSeedOpen(false);
+      setWatchOnlyOpen(false);
       localStorage.setItem("network_type", JSON.stringify({ type: opt.type, network: opt.network, name: opt.name }));
       handleAuthenticated(opt);
-    } else if (opt.type === AuthNetworkTypeEnum.Enum.NONE) {
+    } else if (opt.type === AuthNetworkTypeEnum.Enum.S) {
       setSeedOpen((prev) => !prev);
       setSeed("");
+    } else if (opt.type === AuthNetworkTypeEnum.Enum.WO) {
+      setWatchOnlyOpen((prev) => !prev);
+      setPrincipalAddress("");
     }
   }
   function onSeedChange(e: ChangeEvent<HTMLInputElement>) {
     if (e.target.value.length <= 32) setSeed(e.target.value);
+  }
+  function onPrincipalChange(e: ChangeEvent<HTMLInputElement>) {
+    setPrincipalAddress(e.target.value);
   }
 };
 

--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -15,6 +15,7 @@ import { AuthNetworkTypeEnum, ThemesEnum } from "@/const";
 import { AuthNetwork } from "@redux/models/TokenModels";
 import { CustomInput } from "@components/Input";
 import { decodeIcrcAccount } from "@dfinity/ledger";
+import { clsx } from "clsx";
 
 const Login = () => {
   const { t } = useTranslation();
@@ -83,11 +84,12 @@ const Login = () => {
                               onClick={() => {
                                 handleSeedAuthenticated(seed);
                               }}
-                              className={`w-4 h-4 ${
+                              className={clsx(
+                                "w-4 h-4 opacity-50 cursor-pointer",
                                 seed.length > 0
                                   ? "stroke-BorderSuccessColor"
-                                  : "stroke-PrimaryTextColorLight dark:stroke-PrimaryTextColor"
-                              } opacity-50 cursor-pointer`}
+                                  : "stroke-PrimaryTextColorLight dark:stroke-PrimaryTextColor",
+                              )}
                             />
                             <p className="text-sm text-PrimaryTextColorLight dark:text-PrimaryTextColor">Max 32</p>
                           </div>
@@ -108,11 +110,12 @@ const Login = () => {
                         autoFocus
                         sufix={
                           <CheckIcon
-                            className={`w-4 h-4 ${
+                            className={clsx(
+                              "w-4 h-4 opacity-50 mr-2",
                               principalAddress.length > 0 && !watchOnlyLoginErr
                                 ? "stroke-BorderSuccessColor"
-                                : "stroke-PrimaryTextColorLight dark:stroke-PrimaryTextColor"
-                            } opacity-50 mr-2`}
+                                : "stroke-PrimaryTextColorLight dark:stroke-PrimaryTextColor",
+                            )}
                           />
                         }
                         onKeyDown={(e) => {

--- a/frontend/redux/CheckAuth.tsx
+++ b/frontend/redux/CheckAuth.tsx
@@ -96,9 +96,9 @@ export const handleLoginApp = async (authIdentity: Identity, fromSeed?: boolean,
     store.dispatch(setTokens(userDataJson.tokens));
     setAssetFromLocalData(userDataJson.tokens, myPrincipal.toText());
     dispatchAuths(identityPrincipalStr.toLocaleLowerCase(), myAgent, myPrincipal, !!fixedPrincipal);
-    await updateAllBalances(true, myAgent, userDataJson.tokens, false, true);
+    await updateAllBalances(true, myAgent, userDataJson.tokens, false, true, fixedPrincipal);
   } else {
-    const { tokens } = await updateAllBalances(true, myAgent, defaultTokens, true, true);
+    const { tokens } = await updateAllBalances(true, myAgent, defaultTokens, true, true, fixedPrincipal);
     store.dispatch(setTokens(tokens));
     dispatchAuths(identityPrincipalStr.toLocaleLowerCase(), myAgent, myPrincipal, !!fixedPrincipal);
   }

--- a/frontend/redux/CheckAuth.tsx
+++ b/frontend/redux/CheckAuth.tsx
@@ -31,7 +31,7 @@ export const handleAuthenticated = async (opt: AuthNetwork) => {
     authClient.login({
       maxTimeToLive: BigInt(24 * 60 * 60 * 1000 * 1000 * 1000),
       identityProvider:
-        opt?.type === AuthNetworkTypeEnum.Values.NFID && opt?.type !== undefined && opt?.type !== null
+        !!opt?.type && opt?.type === AuthNetworkTypeEnum.Values.NFID
           ? opt?.network + AUTH_PATH
           : "https://identity.ic0.app/#authorize",
       onSuccess: () => {
@@ -65,7 +65,17 @@ export const handleSeedAuthenticated = (seed: string) => {
   }
 };
 
-export const handleLoginApp = async (authIdentity: Identity, fromSeed?: boolean) => {
+export const handlePrincipalAuthenticated = async (principalAddress: string) => {
+  try {
+    const authClient = await AuthClient.create();
+    const principal = Principal.fromText(principalAddress);
+    handleLoginApp(authClient.getIdentity(), false, principal);
+  } catch {
+    return;
+  }
+};
+
+export const handleLoginApp = async (authIdentity: Identity, fromSeed?: boolean, fixedPrincipal?: Principal) => {
   if (localStorage.getItem("network_type") === null && !fromSeed) {
     logout();
     return;
@@ -76,24 +86,25 @@ export const handleLoginApp = async (authIdentity: Identity, fromSeed?: boolean)
     host: "https://identity.ic0.app",
   });
 
-  const myPrincipal = await myAgent.getPrincipal();
+  const myPrincipal = fixedPrincipal || (await myAgent.getPrincipal());
+  const identityPrincipalStr = fixedPrincipal?.toString() || authIdentity.getPrincipal().toString();
 
   // TOKENS
-  const userData = localStorage.getItem(authIdentity.getPrincipal().toString());
+  const userData = localStorage.getItem(identityPrincipalStr);
   if (userData) {
     const userDataJson = JSON.parse(userData);
     store.dispatch(setTokens(userDataJson.tokens));
     setAssetFromLocalData(userDataJson.tokens, myPrincipal.toText());
-    dispatchAuths(authIdentity, myAgent, myPrincipal);
+    dispatchAuths(identityPrincipalStr.toLocaleLowerCase(), myAgent, myPrincipal, !!fixedPrincipal);
     await updateAllBalances(true, myAgent, userDataJson.tokens, false, true);
   } else {
     const { tokens } = await updateAllBalances(true, myAgent, defaultTokens, true, true);
     store.dispatch(setTokens(tokens));
-    dispatchAuths(authIdentity, myAgent, myPrincipal);
+    dispatchAuths(identityPrincipalStr.toLocaleLowerCase(), myAgent, myPrincipal, !!fixedPrincipal);
   }
 
   // CONTACTS
-  const contactsData = localStorage.getItem("contacts-" + authIdentity.getPrincipal().toString());
+  const contactsData = localStorage.getItem("contacts-" + identityPrincipalStr);
   if (contactsData) {
     const contactsDataJson = JSON.parse(contactsData);
     store.dispatch(setContacts(contactsDataJson.contacts));
@@ -103,9 +114,14 @@ export const handleLoginApp = async (authIdentity: Identity, fromSeed?: boolean)
   await allowanceFullReload();
 };
 
-export const dispatchAuths = (authIdentity: Identity, myAgent: HttpAgent, myPrincipal: Principal) => {
-  store.dispatch(setAuthenticated(true, false, authIdentity.getPrincipal().toText().toLowerCase()));
-  store.dispatch(setStorageCode("contacts-" + authIdentity.getPrincipal().toText().toLowerCase()));
+export const dispatchAuths = (
+  identityPrincipal: string,
+  myAgent: HttpAgent,
+  myPrincipal: Principal,
+  watchOnlyMode: boolean,
+) => {
+  store.dispatch(setAuthenticated(true, false, watchOnlyMode, identityPrincipal));
+  store.dispatch(setStorageCode("contacts-" + identityPrincipal));
   store.dispatch(setUserAgent(myAgent));
   store.dispatch(setUserPrincipal(myPrincipal));
 };

--- a/frontend/redux/assets/AssetActions.tsx
+++ b/frontend/redux/assets/AssetActions.tsx
@@ -31,6 +31,7 @@ export const updateAllBalances = async (
   tokens: Token[],
   basicSearch?: boolean,
   fromLogin?: boolean,
+  fixedPrincipal?: Principal,
 ) => {
   let tokenMarkets: TokenMarketInfo[] = [];
   try {
@@ -62,7 +63,7 @@ export const updateAllBalances = async (
   }
   store.dispatch(setTokenMarket(tokenMarkets));
 
-  const myPrincipal = store.getState().auth.userPrincipal;
+  const myPrincipal = fixedPrincipal || (await myAgent.getPrincipal());
   const tokensAseets = await Promise.all(
     tokens.map(async (tkn, idNum) => {
       try {

--- a/frontend/redux/assets/AssetActions.tsx
+++ b/frontend/redux/assets/AssetActions.tsx
@@ -62,7 +62,7 @@ export const updateAllBalances = async (
   }
   store.dispatch(setTokenMarket(tokenMarkets));
 
-  const myPrincipal = await myAgent.getPrincipal();
+  const myPrincipal = store.getState().auth.userPrincipal;
   const tokensAseets = await Promise.all(
     tokens.map(async (tkn, idNum) => {
       try {
@@ -348,8 +348,7 @@ export const setAssetFromLocalData = (tokens: Token[], myPrincipal: string) => {
 };
 
 export const getAllTransactionsICP = async (subaccount_index: string, loading: boolean, isOGY: boolean) => {
-  const myAgent = store.getState().auth.userAgent;
-  const myPrincipal = await myAgent.getPrincipal();
+  const myPrincipal = store.getState().auth.userPrincipal;
   let subacc: SubAccountNNS | undefined = undefined;
   try {
     subacc = SubAccountNNS.fromBytes(hexToUint8Array(subaccount_index)) as SubAccountNNS;
@@ -411,7 +410,7 @@ export const getAllTransactionsICRC1 = async (
 ) => {
   try {
     const myAgent = store.getState().auth.userAgent;
-    const myPrincipal = await myAgent.getPrincipal();
+    const myPrincipal = store.getState().auth.userPrincipal;
     const canisterPrincipal = Principal.fromText(canister_id);
 
     const { getTransactions: ICRC1_getTransactions } = IcrcIndexCanister.create({

--- a/frontend/redux/auth/AuthReducer.ts
+++ b/frontend/redux/auth/AuthReducer.ts
@@ -10,6 +10,7 @@ interface AuthState {
   authenticated: boolean;
   debugMode: boolean;
   superAdmin: boolean;
+  watchOnlyMode: boolean;
   authClient: string;
   assetList: Asset[];
   theme: string;
@@ -25,6 +26,7 @@ const initialState: AuthState = {
   authenticated: false,
   debugMode: false,
   superAdmin: false,
+  watchOnlyMode: false,
   theme: ThemesEnum.enum.dark,
   blur: false,
   authClient: "",
@@ -48,20 +50,22 @@ const authSlice = createSlice({
       state.authLoading = false;
       state.authenticated = false;
       state.superAdmin = false;
+      state.watchOnlyMode = false;
       state.authClient = "";
       state.debugMode = false;
     },
     setAuthenticated: {
-      reducer(state, action: PayloadAction<{ authenticated: boolean; superAdmin: boolean; authClient: string }>) {
-        const { authenticated, superAdmin, authClient } = action.payload;
+      reducer(state, action: PayloadAction<{ authenticated: boolean; superAdmin: boolean; watchOnlyMode: boolean; authClient: string }>) {
+        const { authenticated, superAdmin, watchOnlyMode, authClient } = action.payload;
         state.authLoading = false;
         state.authenticated = authenticated;
         state.superAdmin = superAdmin;
+        state.watchOnlyMode = watchOnlyMode;
         state.authClient = authClient;
       },
-      prepare(authenticated: boolean, superAdmin: boolean, authClient: string) {
+      prepare(authenticated: boolean, superAdmin: boolean, watchOnlyMode: boolean, authClient: string) {
         return {
-          payload: { authenticated, superAdmin, authClient },
+          payload: { authenticated, superAdmin, watchOnlyMode, authClient },
         };
       },
     },

--- a/public/assets/i18n/translations/en.json
+++ b/public/assets/i18n/translations/en.json
@@ -146,5 +146,6 @@
   "allowance.add.allowance": "Add Allowance",
   "allowance.sure.remove": "Are you sure you want to Remove",
   "allowance.permanently.deleted": "This Allowance will be permanently deleted.",
-  "allowance.edit.allowance": "Edit Allowance"
+  "allowance.edit.allowance": "Edit Allowance",
+  "watchOnlyMode.title": "Watch-Only Mode"
 }

--- a/public/assets/i18n/translations/es.json
+++ b/public/assets/i18n/translations/es.json
@@ -146,5 +146,6 @@
   "allowance.add.allowance": "Agregar Asignación",
   "allowance.sure.remove": "¿Estás seguro de que quieres Eliminar?",
   "allowance.permanently.deleted": "Esta Asignación se eliminará permanentemente.",
-  "allowance.edit.allowance": "Editar Asignación"
+  "allowance.edit.allowance": "Editar Asignación",
+  "watchOnlyMode.title": "Modo Solo-Mirar"
 }

--- a/public/assets/i18n/translations/it.json
+++ b/public/assets/i18n/translations/it.json
@@ -146,5 +146,6 @@
   "allowance.add.allowance": "Aggiungi Allocazione",
   "allowance.sure.remove": "Sei sicuro di voler Eliminare?",
   "allowance.permanently.deleted": "Questa Allocazione verrà eliminata definitivamente.",
-  "allowance.edit.allowance": "Modifica Allocazione"
+  "allowance.edit.allowance": "Modifica Allocazione",
+  "watchOnlyMode.title": "Modalità Solo-Orologio"
 }

--- a/public/assets/i18n/translations/pt.json
+++ b/public/assets/i18n/translations/pt.json
@@ -146,5 +146,6 @@
   "allowance.add.allowance": "Adicionar Mesada",
   "allowance.sure.remove": "Tem certeza de que deseja Remover?",
   "allowance.permanently.deleted": "Esta Mesada será excluída permanentemente.",
-  "allowance.edit.allowance": "Editar Mesada"
+  "allowance.edit.allowance": "Editar Mesada",
+  "watchOnlyMode.title": "Modo Assistir-Apenas"
 }


### PR DESCRIPTION
### Resolves #25 

Adds Watch-Only mode as a login option below SEED option.

By using a PRINCIPAL ID to login in Watch-Only mode user can see:
* Assets and sub accounts
* Contacts
* Transactions history
* Balance

In Watch-Only mode user cannot:
* Send assets to any external wallet
* Add Allowances