### PR TITLE
[BUG] Fix for last selected asset trx data and auto-select new asset

### DIFF
--- a/frontend/pages/home/components/ICRC/asset/AddAsset.tsx
+++ b/frontend/pages/home/components/ICRC/asset/AddAsset.tsx
@@ -13,7 +13,7 @@ import { AssetHook } from "../../../hooks/assetHook";
 import { useAppDispatch } from "@redux/Store";
 import DialogAssetConfirmation from "./DialogAssetConfirmation";
 import AddAssetManual from "./AddAssetManual";
-import { addToken, setAcordeonAssetIdx } from "@redux/assets/AssetReducer";
+import { addToken, setAcordeonAssetIdx, setSelectedAsset } from "@redux/assets/AssetReducer";
 import AddAssetAutomatic from "./AddAssetAutomatic";
 
 interface AddAssetsProps {
@@ -184,6 +184,8 @@ const AddAsset = ({ setAssetOpen, assetOpen, asset, setAssetInfo, tokens, assets
       setAddStatus(AddingAssetsEnum.enum.adding);
       showModal(true);
       dispatch(addToken(tknSave));
+      dispatch(setSelectedAsset(tknSave));
+      dispatch(setAcordeonAssetIdx([tknSave.symbol]));
       reloadBallance(
         [...tokens, tknSave].sort((a, b) => {
           return a.id_number - b.id_number;

--- a/frontend/pages/home/components/ICRC/detail/transaction/TransactionsTable.tsx
+++ b/frontend/pages/home/components/ICRC/detail/transaction/TransactionsTable.tsx
@@ -9,7 +9,7 @@ interface ICRCTransactionsTableProps {
 }
 
 const ICRCTransactionsTable = ({ setDrawerOpen }: ICRCTransactionsTableProps) => {
-  const { transactions } = GeneralHook();
+  const { transactions, selectedAsset } = GeneralHook();
   const { selectedTransaction, changeSelectedTransaction } = UseTransaction();
   const { columns, sorting, setSorting } = TableHook();
   const table = useReactTable({
@@ -45,27 +45,28 @@ const ICRCTransactionsTable = ({ setDrawerOpen }: ICRCTransactionsTableProps) =>
           ))}
         </thead>
         <tbody>
-          {table.getRowModel().rows.map((row, idxTR) => (
-            <tr
-              className={`border-b border-b-BorderColorTwoLight dark:border-b-BorderColorTwo cursor-pointer ${
-                (selectedTransaction?.hash && selectedTransaction?.hash === row.original.hash) ||
-                (selectedTransaction?.idx && selectedTransaction?.idx === row.original.idx)
-                  ? "bg-SelectRowColor/10"
-                  : ""
-              }`}
-              key={`tr-transac-${idxTR}`}
-              onClick={() => {
-                changeSelectedTransaction(row.original);
-                setDrawerOpen(true);
-              }}
-            >
-              {row.getVisibleCells().map((cell, idxTD) => (
-                <td key={`tr-transac-${idxTD}`} className={colStyle(idxTD)}>
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
-              ))}
-            </tr>
-          ))}
+          {transactions[0]?.symbol === selectedAsset?.symbol &&
+            table.getRowModel().rows.map((row, idxTR) => (
+              <tr
+                className={`border-b border-b-BorderColorTwoLight dark:border-b-BorderColorTwo cursor-pointer ${
+                  (selectedTransaction?.hash && selectedTransaction?.hash === row.original.hash) ||
+                  (selectedTransaction?.idx && selectedTransaction?.idx === row.original.idx)
+                    ? "bg-SelectRowColor/10"
+                    : ""
+                }`}
+                key={`tr-transac-${idxTR}`}
+                onClick={() => {
+                  changeSelectedTransaction(row.original);
+                  setDrawerOpen(true);
+                }}
+              >
+                {row.getVisibleCells().map((cell, idxTD) => (
+                  <td key={`tr-transac-${idxTD}`} className={colStyle(idxTD)}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
         </tbody>
       </table>
     </div>

--- a/frontend/pages/home/components/ICRC/detail/transaction/TransactionsTable.tsx
+++ b/frontend/pages/home/components/ICRC/detail/transaction/TransactionsTable.tsx
@@ -9,7 +9,7 @@ interface ICRCTransactionsTableProps {
 }
 
 const ICRCTransactionsTable = ({ setDrawerOpen }: ICRCTransactionsTableProps) => {
-  const { transactions, selectedAsset } = GeneralHook();
+  const { transactions } = GeneralHook();
   const { selectedTransaction, changeSelectedTransaction } = UseTransaction();
   const { columns, sorting, setSorting } = TableHook();
   const table = useReactTable({
@@ -45,28 +45,27 @@ const ICRCTransactionsTable = ({ setDrawerOpen }: ICRCTransactionsTableProps) =>
           ))}
         </thead>
         <tbody>
-          {transactions[0]?.symbol === selectedAsset?.symbol &&
-            table.getRowModel().rows.map((row, idxTR) => (
-              <tr
-                className={`border-b border-b-BorderColorTwoLight dark:border-b-BorderColorTwo cursor-pointer ${
-                  (selectedTransaction?.hash && selectedTransaction?.hash === row.original.hash) ||
-                  (selectedTransaction?.idx && selectedTransaction?.idx === row.original.idx)
-                    ? "bg-SelectRowColor/10"
-                    : ""
-                }`}
-                key={`tr-transac-${idxTR}`}
-                onClick={() => {
-                  changeSelectedTransaction(row.original);
-                  setDrawerOpen(true);
-                }}
-              >
-                {row.getVisibleCells().map((cell, idxTD) => (
-                  <td key={`tr-transac-${idxTD}`} className={colStyle(idxTD)}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                ))}
-              </tr>
-            ))}
+          {table.getRowModel().rows.map((row, idxTR) => (
+            <tr
+              className={`border-b border-b-BorderColorTwoLight dark:border-b-BorderColorTwo cursor-pointer ${
+                (selectedTransaction?.hash && selectedTransaction?.hash === row.original.hash) ||
+                (selectedTransaction?.idx && selectedTransaction?.idx === row.original.idx)
+                  ? "bg-SelectRowColor/10"
+                  : ""
+              }`}
+              key={`tr-transac-${idxTR}`}
+              onClick={() => {
+                changeSelectedTransaction(row.original);
+                setDrawerOpen(true);
+              }}
+            >
+              {row.getVisibleCells().map((cell, idxTD) => (
+                <td key={`tr-transac-${idxTD}`} className={colStyle(idxTD)}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
         </tbody>
       </table>
     </div>

--- a/frontend/pages/home/hooks/useTransaction.tsx
+++ b/frontend/pages/home/hooks/useTransaction.tsx
@@ -61,19 +61,20 @@ export const UseTransaction = () => {
       });
 
       if (founded) dispatch(setTransactions(founded.tx));
+      else dispatch(setTransactions([]));
 
       if (
         selectedAsset?.tokenSymbol === AssetSymbolEnum.Enum.ICP ||
         selectedAsset?.tokenSymbol === AssetSymbolEnum.Enum.OGY
       ) {
         const getICPTx = async () => {
-          await getSelectedSubaccountICPTx(founded ? true : false);
+          await getSelectedSubaccountICPTx(!!founded);
         };
 
         getICPTx();
       } else {
         const getICRCTx = async () => {
-          await getSelectedSubaccountICRCTx(founded ? true : false);
+          await getSelectedSubaccountICRCTx(!!founded);
         };
 
         getICRCTx();


### PR DESCRIPTION
## Current behavior

1.  When selecting assets in AssetList, it could display transaction data from last selected asset if current select haven't got back its own data from API
2. When adding a new asset and the selecting it manually it could have the same issue as bug number 1

## Expected behavior 

1. When changing assets manually in AssetList, it should show its corresponding transaction data from webWorker. If there's any data to show, transaction table should be empty
2. When adding a new asset it should automatically selected so it transaction data can start be fetched from the API and then shown in the transactions table

## Solution

1. Clean transaction data IF after consulting webWorker there no data of current selected asset
2. Set newly added asset as current selected asset and its Accordion open