### PR TITLE
[BUG] watch-only mode refresh not using fixed Principal ID

### DIFF
--- a/frontend/redux/CheckAuth.tsx
+++ b/frontend/redux/CheckAuth.tsx
@@ -96,11 +96,11 @@ export const handleLoginApp = async (authIdentity: Identity, fromSeed?: boolean,
     store.dispatch(setTokens(userDataJson.tokens));
     setAssetFromLocalData(userDataJson.tokens, myPrincipal.toText());
     dispatchAuths(identityPrincipalStr.toLocaleLowerCase(), myAgent, myPrincipal, !!fixedPrincipal);
-    await updateAllBalances(true, myAgent, userDataJson.tokens, false, true, fixedPrincipal);
+    await updateAllBalances(true, myAgent, userDataJson.tokens, false, true);
   } else {
-    const { tokens } = await updateAllBalances(true, myAgent, defaultTokens, true, true, fixedPrincipal);
-    store.dispatch(setTokens(tokens));
     dispatchAuths(identityPrincipalStr.toLocaleLowerCase(), myAgent, myPrincipal, !!fixedPrincipal);
+    const { tokens } = await updateAllBalances(true, myAgent, defaultTokens, true, true);
+    store.dispatch(setTokens(tokens));
   }
 
   // CONTACTS

--- a/frontend/redux/assets/AssetActions.tsx
+++ b/frontend/redux/assets/AssetActions.tsx
@@ -31,7 +31,6 @@ export const updateAllBalances = async (
   tokens: Token[],
   basicSearch?: boolean,
   fromLogin?: boolean,
-  fixedPrincipal?: Principal,
 ) => {
   let tokenMarkets: TokenMarketInfo[] = [];
   try {
@@ -63,7 +62,7 @@ export const updateAllBalances = async (
   }
   store.dispatch(setTokenMarket(tokenMarkets));
 
-  const myPrincipal = fixedPrincipal || (await myAgent.getPrincipal());
+  const myPrincipal = store.getState().auth.userPrincipal;
   const tokensAseets = await Promise.all(
     tokens.map(async (tkn, idNum) => {
       try {


### PR DESCRIPTION
## Current Behavior

Video explanatory https://www.loom.com/share/a45134bab8ed4bfe8d6256002e03ce84

When logging in as watch-only mode, if user click the Refresh button it will update assets with wrong info coming from another Principal ID.

## Expected Behavior

When logging in as watch-only mode, if user click the Refresh button it will update assets with correct info coming from current fixed Principal ID.

## Solution

In `updateAllBalances()` use Principal ID already saved in global state, as it will contain either a fixed Principal ID if using watch-only mode or the Principal ID from the current Identity agent.