### PR TITLE
[BUG] watch-only mode unable to login

### DIFF
--- a/frontend/redux/CheckAuth.tsx
+++ b/frontend/redux/CheckAuth.tsx
@@ -78,7 +78,7 @@ export const handlePrincipalAuthenticated = async (principalAddress: string) => 
 };
 
 export const handleLoginApp = async (authIdentity: Identity, fromSeed?: boolean, fixedPrincipal?: Principal) => {
-  if (localStorage.getItem("network_type") === null && !fromSeed) {
+  if (localStorage.getItem("network_type") === null && !fromSeed && !fixedPrincipal) {
     logout();
     return;
   }


### PR DESCRIPTION
## Current Behavior
Unable to login as watch-only mode after entering a correct PRINCIPAL ID and the hit the ENTER key.

## Expected Behavior
Successfully login in as watch-only mode after entering a correct PRINCIPAL ID and then hit the ENTER key.

## Solution
Prevent watch-only login to be forced to logout.