### PR TITLE
[BUG] Watch-only not using fixed principal for fetching Contacts data

### DIFF
--- a/frontend/pages/home/hooks/assetHook.tsx
+++ b/frontend/pages/home/hooks/assetHook.tsx
@@ -1,6 +1,6 @@
 import { defaultTokens } from "@/defaultTokens";
 import contactCacheRefresh from "@pages/contacts/helpers/contacts";
-import { useAppDispatch, useAppSelector } from "@redux/Store";
+import store, { useAppDispatch, useAppSelector } from "@redux/Store";
 import { updateAllBalances } from "@redux/assets/AssetActions";
 import {
   removeToken,
@@ -36,8 +36,8 @@ export const AssetHook = () => {
   const reloadBallance = async (tkns?: Token[]) => {
     dispatch(setLoading(true));
     updateAllBalances(true, userAgent, tkns ? tkns : tokens.length > 0 ? tokens : defaultTokens);
-    const principal = (await userAgent.getPrincipal()).toText();
-    allowanceCacheRefresh(principal);
+    const principal = store.getState().auth.userPrincipal.toText();
+    await allowanceCacheRefresh(principal);
     await contactCacheRefresh(principal);
   };
 


### PR DESCRIPTION
## Current Behavior
Contacts data won't show up even after clicking the REFRESH button.

## Expected Behavior
Contact data will show up and remain visible even after clicking the REFRESH button.

## Solution
We should always get the `Principal` from `userPrincipal` property in global state, because watch-only mode uses an Anonymous Identity to login, and we need to be able to retrieve information from the fixed Principal ID inputed in Login page.