### PR TITLE
feat/icrc transfer polling

### DIFF
--- a/frontend/@types/transactions.ts
+++ b/frontend/@types/transactions.ts
@@ -180,3 +180,21 @@ export type TransactionReceiverOption = z.infer<typeof TransactionReceiverOption
 
 export const TransactionScannerOptionEnum = z.enum(["sender", "receiver", "none"]);
 export type TransactionScannerOption = z.infer<typeof TransactionScannerOptionEnum>;
+
+export const transactionErrors: KeyValidationErrors = {
+  [TransactionValidationErrorsEnum.Values["error.asset.empty"]]: TransactionValidationErrorsEnum.Values["error.asset.empty"],
+  [TransactionValidationErrorsEnum.Values["error.sender.empty"]]: TransactionValidationErrorsEnum.Values["error.sender.empty"],
+  [TransactionValidationErrorsEnum.Values["error.receiver.empty"]]: TransactionValidationErrorsEnum.Values["error.receiver.empty"],
+  [TransactionValidationErrorsEnum.Values["error.own.sender.not.allowed"]]: TransactionValidationErrorsEnum.Values["error.own.sender.not.allowed"],
+  [TransactionValidationErrorsEnum.Values["error.same.sender.receiver"]]: TransactionValidationErrorsEnum.Values["error.same.sender.receiver"],
+  [TransactionValidationErrorsEnum.Values["error.invalid.sender.principal"]]: TransactionValidationErrorsEnum.Values["error.invalid.sender.principal"],
+  [TransactionValidationErrorsEnum.Values["error.invalid.sender.subaccount"]]: TransactionValidationErrorsEnum.Values["error.invalid.sender.subaccount"],
+  [TransactionValidationErrorsEnum.Values["error.invalid.receiver.principal"]]: TransactionValidationErrorsEnum.Values["error.invalid.receiver.principal"],
+  [TransactionValidationErrorsEnum.Values["error.invalid.receiver.subaccount"]]: TransactionValidationErrorsEnum.Values["error.invalid.receiver.subaccount"],
+  [TransactionValidationErrorsEnum.Values["invalid.receiver.identifier"]]: TransactionValidationErrorsEnum.Values["invalid.receiver.identifier"],
+  [TransactionValidationErrorsEnum.Values["error.invalid.sender"]]: TransactionValidationErrorsEnum.Values["error.invalid.sender"],
+  [TransactionValidationErrorsEnum.Values["error.invalid.receiver"]]: TransactionValidationErrorsEnum.Values["error.invalid.receiver"],
+  [TransactionValidationErrorsEnum.Values["error.invalid.amount"]]: TransactionValidationErrorsEnum.Values["error.invalid.amount"],
+  [TransactionValidationErrorsEnum.Values["error.not.enough.balance"]]: TransactionValidationErrorsEnum.Values["error.not.enough.balance"],
+  [TransactionValidationErrorsEnum.Values["error.allowance.subaccount.not.enough"]]: TransactionValidationErrorsEnum.Values["error.allowance.subaccount.not.enough"],
+};

--- a/frontend/components/CalendarPicker.tsx
+++ b/frontend/components/CalendarPicker.tsx
@@ -3,7 +3,7 @@ import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { DateTimePicker, DateTimePickerProps } from "@mui/x-date-pickers/DateTimePicker";
 import { renderTimeViewClock } from "@mui/x-date-pickers/timeViewRenderers";
 import { ThemeHook } from "@/pages/hooks/themeHook";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import dayjs from "dayjs";
 
 interface CalendarDatePickerProps extends DateTimePickerProps<dayjs.Dayjs> {

--- a/frontend/components/drawer/Drawer.tsx
+++ b/frontend/components/drawer/Drawer.tsx
@@ -1,6 +1,6 @@
 import { ReactComponent as CloseIcon } from "@assets/svg/files/close.svg";
 import { getDrawerBlank, getDrawerContainerStyle } from "./styles.cva";
-import clsx from "clsx";
+import { clsx } from "clsx";
 
 interface IDrawerProps {
   isDrawerOpen: boolean;

--- a/frontend/components/drawer/styles.cva.ts
+++ b/frontend/components/drawer/styles.cva.ts
@@ -1,4 +1,4 @@
-import clsx from "clsx";
+import { clsx } from "clsx";
 
 export function getDrawerContainerStyle(isDrawerOpen: boolean) {
   return clsx(

--- a/frontend/components/select/Select.tsx
+++ b/frontend/components/select/Select.tsx
@@ -6,7 +6,7 @@ import { CustomInput } from "@components/Input";
 import SearchIcon from "@assets/svg/files/icon-search.svg";
 import { SelectOption } from "@/@types/components";
 import { selectContentCVA, selectTriggerCVA } from "./styles.cva";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import { useTranslation } from "react-i18next";
 
 interface TSelectProps extends VariantProps<typeof selectTriggerCVA>, VariantProps<typeof selectContentCVA> {

--- a/frontend/components/table/index.tsx
+++ b/frontend/components/table/index.tsx
@@ -1,4 +1,4 @@
-import clsx from "clsx";
+import { clsx } from "clsx";
 import { ReactNode } from "react";
 
 interface CommonProps {

--- a/frontend/components/tabs/Tab.tsx
+++ b/frontend/components/tabs/Tab.tsx
@@ -1,4 +1,4 @@
-import clsx from "clsx";
+import { clsx } from "clsx";
 
 interface TabProps {
   tabs: { tabName: string; content: JSX.Element; disabled?: boolean }[];

--- a/frontend/defaultTokens.ts
+++ b/frontend/defaultTokens.ts
@@ -1,7 +1,7 @@
 import { Token } from "@redux/models/TokenModels";
 import { SupportedStandardEnum } from "./@types/icrc";
 import { getMetadataInfo } from "./utils";
-import { IcrcLedgerCanister } from "@dfinity/ledger";
+import { IcrcLedgerCanister } from "@dfinity/ledger-icrc";
 import { HttpAgent } from "@dfinity/agent";
 
 interface SnsMetadata {
@@ -157,7 +157,6 @@ export const mapSnsToToken = async (sns: SnsMetadata, id: number, myAgent: HttpA
   const { metadata } = IcrcLedgerCanister.create({ agent: myAgent, canisterId: address as any });
 
   const currentMetadata = await metadata({ certified: false });
-
   const { name, symbol, decimals, logo, fee } = getMetadataInfo(currentMetadata);
 
   return {

--- a/frontend/pages/components/topbar/dbLocationModal.tsx
+++ b/frontend/pages/components/topbar/dbLocationModal.tsx
@@ -12,7 +12,7 @@ import { CustomInput } from "@components/Input";
 import { ThemesEnum } from "@/const";
 import { db, DB_Type } from "@/database/db";
 import store from "@/redux/Store";
-import { decodeIcrcAccount } from "@dfinity/ledger";
+import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 
 interface DbLocationModalProps {
   setOpen(value: boolean): void;

--- a/frontend/pages/contacts/components/ICRC/AddContact/index.tsx
+++ b/frontend/pages/contacts/components/ICRC/AddContact/index.tsx
@@ -13,7 +13,7 @@ import LoadingLoader from "@components/Loader";
 import { CustomButton } from "@components/Button";
 import { AssetContact } from "@redux/models/ContactsModels";
 import { isHexadecimalValid, validateSubaccounts } from "@/utils/checkers";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import { validatePrincipal } from "@/utils/identity";
 import { SupportedStandardEnum } from "@/@types/icrc";
 import { db } from "@/database/db";

--- a/frontend/pages/contacts/components/ICRC/AssetFilter.tsx
+++ b/frontend/pages/contacts/components/ICRC/AssetFilter.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next";
 import ChevronRightIcon from "@assets/svg/files/chevron-right-icon.svg";
 import ChevronRightDarkIcon from "@assets/svg/files/chevron-right-dark-icon.svg";
 import { Asset } from "@redux/models/AccountModels";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import { CustomCheck } from "@components/CheckBox";
 
 interface AssetFilterProps {

--- a/frontend/pages/contacts/components/ICRC/SubAccountBody.tsx
+++ b/frontend/pages/contacts/components/ICRC/SubAccountBody.tsx
@@ -10,7 +10,7 @@ import { Buffer } from "buffer";
 
 import { CustomCopy } from "@components/CopyTooltip";
 import { CustomInput } from "@components/Input";
-import { encodeIcrcAccount } from "@dfinity/ledger";
+import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
 import { getInitialFromName, hexToUint8Array, removeLeadingZeros, shortAddress } from "@/utils";
 import AllowanceTooltip from "./AllowanceTooltip";

--- a/frontend/pages/contacts/hooks/usePrincipalValidator.ts
+++ b/frontend/pages/contacts/hooks/usePrincipalValidator.ts
@@ -1,4 +1,4 @@
-import { decodeIcrcAccount } from "@dfinity/ledger";
+import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { useAppSelector } from "@redux/Store";
 
 export default function usePrincipalValidator() {

--- a/frontend/pages/home/components/ICRC/allowance/ActionCard.tsx
+++ b/frontend/pages/home/components/ICRC/allowance/ActionCard.tsx
@@ -3,7 +3,7 @@ import { ReactComponent as PencilIcon } from "@assets/svg/files/pencil.svg";
 import { ReactComponent as DotsIcon } from "@assets/svg/files/dots-icon.svg";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { TAllowance } from "@/@types/allowance";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import { useTranslation } from "react-i18next";
 import useAllowanceDrawer from "@pages/home/hooks/useAllowanceDrawer";
 import { setIsDeleteAllowanceAction, setSelectedAllowanceAction } from "@redux/allowance/AllowanceActions";

--- a/frontend/pages/home/components/ICRC/allowance/AllowanceList.tsx
+++ b/frontend/pages/home/components/ICRC/allowance/AllowanceList.tsx
@@ -4,7 +4,7 @@ import { Table, TableBody, TableBodyCell, TableHead, TableHeaderCell, TableRow }
 import useAllowanceTable from "@pages/home/hooks/useAllowanceTable";
 import useAllowances from "@pages/home/hooks/useAllowances";
 import { flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import UpdateAllowanceDrawer from "./UpdateAllowanceDrawer";
 import DeleteAllowanceModal from "./DeleteAllowanceModal";
 

--- a/frontend/pages/home/components/ICRC/allowance/DeleteAllowanceModal.tsx
+++ b/frontend/pages/home/components/ICRC/allowance/DeleteAllowanceModal.tsx
@@ -13,7 +13,7 @@ import {
   setSelectedAllowanceAction,
 } from "@redux/allowance/AllowanceActions";
 import { initialAllowanceState } from "@redux/allowance/AllowanceReducer";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 

--- a/frontend/pages/home/components/ICRC/allowance/UpdateForm/FixedFieldsFormItem.tsx
+++ b/frontend/pages/home/components/ICRC/allowance/UpdateForm/FixedFieldsFormItem.tsx
@@ -4,7 +4,7 @@ import { getAssetIcon } from "@/utils/icons";
 import { middleTruncation } from "@/utils/strings";
 import { Chip } from "@components/chip";
 import { useAppSelector } from "@redux/Store";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 

--- a/frontend/pages/home/components/ICRC/asset/AddAssetManual.tsx
+++ b/frontend/pages/home/components/ICRC/asset/AddAssetManual.tsx
@@ -2,7 +2,7 @@
 import { ReactComponent as InfoIcon } from "@assets/svg/files/info-icon.svg";
 //
 import { GeneralHook } from "../../../hooks/generalHook";
-import { IcrcIndexCanister, IcrcLedgerCanister } from "@dfinity/ledger";
+import { IcrcIndexCanister, IcrcLedgerCanister } from "@dfinity/ledger-icrc";
 import { getMetadataInfo, toFullDecimal } from "@/utils";
 import { CustomInput } from "@components/Input";
 import { CustomCopy } from "@components/CopyTooltip";

--- a/frontend/pages/home/components/ICRC/asset/DialogAddAsset.tsx
+++ b/frontend/pages/home/components/ICRC/asset/DialogAddAsset.tsx
@@ -14,7 +14,7 @@ import { useAppDispatch } from "@redux/Store";
 import { addSubAccount, setAcordeonAssetIdx } from "@redux/assets/AssetReducer";
 import bigInt from "big-integer";
 import { ChangeEvent, useState } from "react";
-import { IcrcLedgerCanister } from "@dfinity/ledger";
+import { IcrcLedgerCanister } from "@dfinity/ledger-icrc";
 import { db } from "@/database/db";
 
 interface DialogAddAssetProps {

--- a/frontend/pages/home/components/ICRC/detail/subaccountTableInfo.tsx
+++ b/frontend/pages/home/components/ICRC/detail/subaccountTableInfo.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Dispatch, PropsWithChildren, SetStateAction, useEffect, useMemo } from "react";
 import AddAllowanceButton from "../allowance/AddAllowanceButton";
 import { Tab } from "@components/tabs";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import { useAppSelector } from "@redux/Store";
 import { SupportedStandardEnum } from "@/@types/icrc";
 

--- a/frontend/pages/home/components/ICRC/detail/transaction/SendForm/ContactScannerReceiver.tsx
+++ b/frontend/pages/home/components/ICRC/detail/transaction/SendForm/ContactScannerReceiver.tsx
@@ -3,7 +3,7 @@ import { ReactComponent as SearchIcon } from "@assets/svg/files/icon-search.svg"
 import { ChangeEvent, useEffect, useState } from "react";
 import { removeErrorAction, setErrorAction, setReceiverNewContactAction } from "@redux/transaction/TransactionActions";
 import { useTranslation } from "react-i18next";
-import { decodeIcrcAccount, encodeIcrcAccount } from "@dfinity/ledger";
+import { decodeIcrcAccount, encodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { hexToUint8Array, subUint8ArrayToHex } from "@/utils";
 import ContactSuffix from "./ContactSuffix";
 import { TransactionValidationErrorsEnum } from "@/@types/transactions";

--- a/frontend/pages/home/components/ICRC/detail/transaction/SendForm/ReceiverQRScanner.tsx
+++ b/frontend/pages/home/components/ICRC/detail/transaction/SendForm/ReceiverQRScanner.tsx
@@ -1,6 +1,6 @@
 import { TransactionScannerOptionEnum } from "@/@types/transactions";
 import { subUint8ArrayToHex } from "@/utils";
-import { decodeIcrcAccount } from "@dfinity/ledger";
+import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import QRscanner from "@pages/components/QRscanner";
 import { setReceiverNewContactAction, setScannerActiveOptionAction } from "@redux/transaction/TransactionActions";
 

--- a/frontend/pages/home/components/ICRC/detail/transaction/SendForm/SenderQRScanner.tsx
+++ b/frontend/pages/home/components/ICRC/detail/transaction/SendForm/SenderQRScanner.tsx
@@ -1,6 +1,6 @@
 import { TransactionScannerOptionEnum, TransactionSenderOptionEnum } from "@/@types/transactions";
 import { subUint8ArrayToHex } from "@/utils";
-import { decodeIcrcAccount } from "@dfinity/ledger";
+import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import QRscanner from "@pages/components/QRscanner";
 import {
   setIsNewSenderAction,

--- a/frontend/pages/home/components/ICRC/detail/transaction/SendForm/SenderType.tsx
+++ b/frontend/pages/home/components/ICRC/detail/transaction/SendForm/SenderType.tsx
@@ -3,7 +3,7 @@ import { TransactionSenderOption, TransactionSenderOptionEnum } from "@/@types/t
 import * as RadioGroup from "@radix-ui/react-radio-group";
 import { useAppSelector } from "@redux/Store";
 import { clearSenderAction, setSenderOptionAction } from "@redux/transaction/TransactionActions";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 

--- a/frontend/pages/home/components/ICRC/detail/transaction/SendForm/TransactionAmount.tsx
+++ b/frontend/pages/home/components/ICRC/detail/transaction/SendForm/TransactionAmount.tsx
@@ -5,7 +5,7 @@ import { getSubAccountBalance } from "@pages/home/helpers/icrc";
 import useSend from "@pages/home/hooks/useSend";
 import { useAppSelector } from "@redux/Store";
 import { removeErrorAction, setAmountAction, setErrorAction } from "@redux/transaction/TransactionActions";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import { ChangeEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 

--- a/frontend/pages/home/components/ICRC/detail/transaction/SendForm/index.tsx
+++ b/frontend/pages/home/components/ICRC/detail/transaction/SendForm/index.tsx
@@ -13,7 +13,7 @@ import useSend from "@pages/home/hooks/useSend";
 import SenderAsset from "./SenderAsset";
 import { useTranslation } from "react-i18next";
 import { useAppSelector } from "@redux/Store";
-import { TransactionValidationErrorsEnum } from "@/@types/transactions";
+import { TransactionValidationErrorsEnum, transactionErrors } from "@/@types/transactions";
 import LoadingLoader from "@components/Loader";
 
 interface SendFormProps {
@@ -87,23 +87,9 @@ export default function SendForm({ setDrawerOpen }: SendFormProps) {
   }
 
   function getError() {
-    switch (true) {
-      case errors?.includes(TransactionValidationErrorsEnum.Values["error.asset.empty"]):
-        return TransactionValidationErrorsEnum.Values["error.asset.empty"];
-      case errors?.includes(TransactionValidationErrorsEnum.Values["error.invalid.sender"]):
-        return TransactionValidationErrorsEnum.Values["error.invalid.sender"];
-      case errors?.includes(TransactionValidationErrorsEnum.Values["error.invalid.receiver"]):
-        return TransactionValidationErrorsEnum.Values["error.invalid.receiver"];
-      case errors?.includes(TransactionValidationErrorsEnum.Values["error.sender.empty"]):
-        return TransactionValidationErrorsEnum.Values["error.sender.empty"];
-      case errors?.includes(TransactionValidationErrorsEnum.Values["error.receiver.empty"]):
-        return TransactionValidationErrorsEnum.Values["error.receiver.empty"];
-      case errors?.includes(TransactionValidationErrorsEnum.Values["error.own.sender.not.allowed"]):
-        return TransactionValidationErrorsEnum.Values["error.own.sender.not.allowed"];
-      case errors?.includes(TransactionValidationErrorsEnum.Values["error.same.sender.receiver"]):
-        return TransactionValidationErrorsEnum.Values["error.same.sender.receiver"];
-      default:
-        return "";
-    }
+    if (!errors || !errors?.length) return "";
+    const error = transactionErrors[errors[0]];
+    if (error) return error;
+    return "";
   }
 }

--- a/frontend/pages/home/components/ICRC/detail/transaction/Transaction.tsx
+++ b/frontend/pages/home/components/ICRC/detail/transaction/Transaction.tsx
@@ -10,7 +10,7 @@ import { getAddress, getAssetSymbol, getICRC1Acc, hexToUint8Array, shortAddress,
 import { AssetSymbolEnum, SpecialTxTypeEnum, TransactionTypeEnum } from "@/const";
 import { Principal } from "@dfinity/principal";
 import { AccountHook } from "@pages/hooks/accountHook";
-import { IcrcAccount } from "@dfinity/ledger";
+import { IcrcAccount } from "@dfinity/ledger-icrc";
 import { CustomCopy } from "@components/CopyTooltip";
 import { AssetHook } from "@pages/home/hooks/assetHook";
 import { GeneralHook } from "@pages/home/hooks/generalHook";
@@ -37,11 +37,11 @@ const DrawerTransaction = ({ setDrawerOpen }: DrawerTransactionProps) => {
 
   return (
     <Fragment>
-      <div className="flex flex-col justify-start items-center bg-PrimaryColorLight dark:bg-SideColor w-full h-full pt-8 text-md text-PrimaryTextColorLight/70 dark:text-PrimaryTextColor/70">
+      <div className="flex flex-col items-center justify-start w-full h-full pt-8 bg-PrimaryColorLight dark:bg-SideColor text-md text-PrimaryTextColorLight/70 dark:text-PrimaryTextColor/70">
         {/* TITLE SECTION */}
-        <div className="flex flex-row justify-between items-center w-full mb-4 px-6">
-          <div className="flex flex-row justify-start items-center gap-7">
-            <p className="font-semibold text-lg text-PrimaryTextColorLight dark:text-PrimaryTextColor">
+        <div className="flex flex-row items-center justify-between w-full px-6 mb-4">
+          <div className="flex flex-row items-center justify-start gap-7">
+            <p className="text-lg font-semibold text-PrimaryTextColorLight dark:text-PrimaryTextColor">
               {selectedTransaction?.kind === SpecialTxTypeEnum.Enum.mint
                 ? "Mint"
                 : selectedTransaction?.kind === SpecialTxTypeEnum.Enum.burn
@@ -74,12 +74,12 @@ const DrawerTransaction = ({ setDrawerOpen }: DrawerTransactionProps) => {
         {/* FROM SECTION */}
         {selectedTransaction?.kind !== SpecialTxTypeEnum.Enum.mint && (
           <div className="flex flex-col justify-center items-center gap-4 w-[calc(100%-3rem)] mx-6 p-4 bg-FromBoxColorLight dark:bg-FromBoxColor">
-            <div className="flex flex-row justify-between items-center w-full">
-              <p className="text-PrimaryTextColorLight dark:text-PrimaryTextColor font-medium">{t("from")}</p>
+            <div className="flex flex-row items-center justify-between w-full">
+              <p className="font-medium text-PrimaryTextColorLight dark:text-PrimaryTextColor">{t("from")}</p>
             </div>
-            <div className="flex flex-row justify-between items-center w-full font-normal">
+            <div className="flex flex-row items-center justify-between w-full font-normal">
               <p>{`${t("acc.principal")}`}</p>
-              <div className="flex flex-row justify-start items-center gap-2">
+              <div className="flex flex-row items-center justify-start gap-2">
                 <p>{`${hasSub(false) ? shortAddress(getPrincipal(false), 12, 12) : t("unknown")}`}</p>
                 <CustomCopy
                   size={"small"}
@@ -89,9 +89,9 @@ const DrawerTransaction = ({ setDrawerOpen }: DrawerTransactionProps) => {
                 />
               </div>
             </div>
-            <div className="flex flex-row justify-between items-center w-full font-normal">
+            <div className="flex flex-row items-center justify-between w-full font-normal">
               <p>{`${t("acc.subacc")}`}</p>
-              <div className="flex flex-row justify-start items-center gap-2">
+              <div className="flex flex-row items-center justify-start gap-2">
                 <p>{`${hasSub(false) ? getSub(false) : t("unknown")}`}</p>
                 <CustomCopy
                   size={"small"}
@@ -101,9 +101,9 @@ const DrawerTransaction = ({ setDrawerOpen }: DrawerTransactionProps) => {
                 />
               </div>
             </div>
-            <div className="flex flex-row justify-between items-center w-full font-normal">
+            <div className="flex flex-row items-center justify-between w-full font-normal">
               <p>{`${t("icrc.acc")}`}</p>
-              <div className="flex flex-row justify-start items-center gap-2">
+              <div className="flex flex-row items-center justify-start gap-2">
                 <p>{`${hasSub(false) ? shortAddress(getICRCAccount(false), 12, 12) : t("unknown")}`}</p>
                 <CustomCopy
                   size={"small"}
@@ -114,9 +114,9 @@ const DrawerTransaction = ({ setDrawerOpen }: DrawerTransactionProps) => {
               </div>
             </div>
             {selectedTransaction?.symbol === AssetSymbolEnum.Enum.ICP && (
-              <div className="flex flex-row justify-between items-center w-full font-normal">
+              <div className="flex flex-row items-center justify-between w-full font-normal">
                 <p>{`${t("acc.identifier")}`}</p>
-                <div className="flex flex-row justify-start items-center gap-2">
+                <div className="flex flex-row items-center justify-start gap-2">
                   <p>{`${shortAddress(getIdentifier(false), 12, 12)}`}</p>
                   <CustomCopy
                     size={"small"}
@@ -127,7 +127,7 @@ const DrawerTransaction = ({ setDrawerOpen }: DrawerTransactionProps) => {
                 </div>
               </div>
             )}
-            <div className="flex flex-row justify-between items-center w-full font-normal">
+            <div className="flex flex-row items-center justify-between w-full font-normal">
               <p>{t("transaction.amount")}</p>
               <p className="">{`${toFullDecimal(
                 BigInt(selectedTransaction?.amount || "0") + BigInt(selectedAccount?.transaction_fee || "0"),
@@ -142,12 +142,12 @@ const DrawerTransaction = ({ setDrawerOpen }: DrawerTransactionProps) => {
         {/* TO SECTION */}
         {selectedTransaction?.kind !== SpecialTxTypeEnum.Enum.burn && (
           <div className="flex flex-col justify-center items-center gap-4 w-[calc(100%-3rem)] mx-6 p-4 bg-FromBoxColorLight dark:bg-FromBoxColor rounded-md">
-            <div className="flex flex-row justify-between items-center w-full">
-              <p className="text-PrimaryTextColorLight dark:text-PrimaryTextColor font-medium">{t("to")}</p>
+            <div className="flex flex-row items-center justify-between w-full">
+              <p className="font-medium text-PrimaryTextColorLight dark:text-PrimaryTextColor">{t("to")}</p>
             </div>
-            <div className="flex flex-row justify-between items-center w-full font-normal">
+            <div className="flex flex-row items-center justify-between w-full font-normal">
               <p>{`${t("acc.principal")}`}</p>
-              <div className="flex flex-row justify-start items-center gap-2">
+              <div className="flex flex-row items-center justify-start gap-2">
                 <p>{`${hasSub(true) ? shortAddress(getPrincipal(true), 12, 12) : t("unknown")}`}</p>
                 <CustomCopy
                   size={"small"}
@@ -157,9 +157,9 @@ const DrawerTransaction = ({ setDrawerOpen }: DrawerTransactionProps) => {
                 />
               </div>
             </div>
-            <div className="flex flex-row justify-between items-center w-full font-normal">
+            <div className="flex flex-row items-center justify-between w-full font-normal">
               <p>{`${t("acc.subacc")}`}</p>
-              <div className="flex flex-row justify-start items-center gap-2">
+              <div className="flex flex-row items-center justify-start gap-2">
                 <p>{`${hasSub(true) ? getSub(true) : t("unknown")}`}</p>
                 <CustomCopy
                   size={"small"}
@@ -169,9 +169,9 @@ const DrawerTransaction = ({ setDrawerOpen }: DrawerTransactionProps) => {
                 />
               </div>
             </div>
-            <div className="flex flex-row justify-between items-center w-full font-normal">
+            <div className="flex flex-row items-center justify-between w-full font-normal">
               <p>{`${t("icrc.acc")}`}</p>
-              <div className="flex flex-row justify-start items-center gap-2">
+              <div className="flex flex-row items-center justify-start gap-2">
                 <p>{`${hasSub(true) ? shortAddress(getICRCAccount(true), 12, 12) : t("unknown")}`}</p>
                 <CustomCopy
                   size={"small"}
@@ -182,9 +182,9 @@ const DrawerTransaction = ({ setDrawerOpen }: DrawerTransactionProps) => {
               </div>
             </div>
             {selectedTransaction?.symbol === AssetSymbolEnum.Enum.ICP && (
-              <div className="flex flex-row justify-between items-center w-full font-normal">
+              <div className="flex flex-row items-center justify-between w-full font-normal">
                 <p>{`${t("acc.identifier")}`}</p>
-                <div className="flex flex-row justify-start items-center gap-2">
+                <div className="flex flex-row items-center justify-start gap-2">
                   <p>{`${shortAddress(getIdentifier(true), 12, 12)}`}</p>
                   <CustomCopy
                     size={"small"}
@@ -195,7 +195,7 @@ const DrawerTransaction = ({ setDrawerOpen }: DrawerTransactionProps) => {
                 </div>
               </div>
             )}
-            <div className="flex flex-row justify-between items-center w-full font-normal">
+            <div className="flex flex-row items-center justify-between w-full font-normal">
               <p>{t("transaction.amount")}</p>
               <p className="">{`${toFullDecimal(
                 BigInt(selectedTransaction?.amount || "0"),
@@ -206,7 +206,7 @@ const DrawerTransaction = ({ setDrawerOpen }: DrawerTransactionProps) => {
         )}
         {selectedTransaction?.kind !== SpecialTxTypeEnum.Enum.mint && (
           <div className="flex flex-col justify-center items-center gap-4 w-[calc(100%-3rem)] mx-6 mt-5 p-4 bg-FromBoxColorLight dark:bg-FromBoxColor rounded-md">
-            <div className="flex flex-row justify-between items-center w-full font-normal">
+            <div className="flex flex-row items-center justify-between w-full font-normal">
               <p className="font-bold">{t("fee")}</p>
               <p className="font-bold">{`${toFullDecimal(
                 BigInt(selectedAccount?.transaction_fee || "0"),

--- a/frontend/pages/home/components/ICRC/drawer/DrawerReceive.tsx
+++ b/frontend/pages/home/components/ICRC/drawer/DrawerReceive.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from "react";
 import { GeneralHook } from "../../../hooks/generalHook";
-import { encodeIcrcAccount } from "@dfinity/ledger";
+import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
 import { hexToUint8Array } from "@/utils";
 import QRCode from "react-qr-code";

--- a/frontend/pages/home/components/ICRC/drawer/SendOutAccount.tsx
+++ b/frontend/pages/home/components/ICRC/drawer/SendOutAccount.tsx
@@ -5,7 +5,7 @@ import QRIcon from "@assets/svg/files/qr.svg";
 //
 import { CustomButton } from "@components/Button";
 import { CustomInput } from "@components/Input";
-import { IcrcAccount, decodeIcrcAccount, encodeIcrcAccount } from "@dfinity/ledger";
+import { IcrcAccount, decodeIcrcAccount, encodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
 import { getICRC1Acc, shortAddress, subUint8ArrayToHex, getFirstNFrom, hexToUint8Array, checkHexString } from "@/utils";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";

--- a/frontend/pages/home/helpers/icrc/getICRCSupportedStandards.ts
+++ b/frontend/pages/home/helpers/icrc/getICRCSupportedStandards.ts
@@ -1,14 +1,11 @@
+import { getIcrcActor } from "./getIcrcActor";
 import { SupportedStandard } from "@/@types/icrc";
-import { Actor, HttpAgent } from "@dfinity/agent";
-import { Principal } from "@dfinity/principal";
+import { HttpAgent } from "@dfinity/agent";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 dayjs.extend(utc);
 //
-import { _SERVICE as LedgerActor } from "@candid/icrcLedger/icrcLedgerService";
-import { idlFactory as LedgerFactory } from "@candid/icrcLedger/icrcLedgerCandid.did";
-// import { PollStrategy, PollStrategyFactory } from "@dfinity/agent/lib/cjs/polling";
-import { backoff, chain, conditionalDelay, once, timeout } from "@dfinity/agent/lib/cjs/polling/strategy";
+
 
 interface ICRCSupportedStandardsParams {
     assetAddress: string;
@@ -18,10 +15,9 @@ interface ICRCSupportedStandardsParams {
 export async function getICRCSupportedStandards(params: ICRCSupportedStandardsParams): Promise<SupportedStandard[]> {
     try {
         const { assetAddress, agent } = params;
-        const canisterId = Principal.fromText(assetAddress);
-        const ledgerActor = Actor.createActor<LedgerActor>(LedgerFactory, {
+        const ledgerActor = getIcrcActor({
             agent,
-            canisterId,
+            assetAddress,
         });
         const response = await ledgerActor.icrc1_supported_standards();
         return response.map((standard) => standard.name as SupportedStandard);
@@ -30,16 +26,3 @@ export async function getICRCSupportedStandards(params: ICRCSupportedStandardsPa
         return [];
     }
 }
-
-const FIVE_MINUTES_IN_MSEC = 5 * 60 * 1000;
-
-export function getIcrcActor(params: ICRCSupportedStandardsParams): LedgerActor {
-    const { assetAddress, agent } = params;
-    const canisterId = Principal.fromText(assetAddress);
-    const ledgerActor = Actor.createActor<LedgerActor>(LedgerFactory, {
-        agent,
-        canisterId,
-        pollingStrategyFactory: () => chain(conditionalDelay(once(), 1000), backoff(1000, 1.2), timeout(FIVE_MINUTES_IN_MSEC)),
-    });
-    return ledgerActor;
-};

--- a/frontend/pages/home/helpers/icrc/getICRCSupportedStandards.ts
+++ b/frontend/pages/home/helpers/icrc/getICRCSupportedStandards.ts
@@ -1,4 +1,4 @@
-import { getIcrcActor } from "./getIcrcActor";
+import { getIcrcActor } from "@/pages/home/helpers/icrc";
 import { SupportedStandard } from "@/@types/icrc";
 import { HttpAgent } from "@dfinity/agent";
 import dayjs from "dayjs";

--- a/frontend/pages/home/helpers/icrc/getIcrcActor.ts
+++ b/frontend/pages/home/helpers/icrc/getIcrcActor.ts
@@ -6,19 +6,35 @@ import { _SERVICE as LedgerActor } from "@candid/icrcLedger/icrcLedgerService";
 import { idlFactory as LedgerFactory } from "@candid/icrcLedger/icrcLedgerCandid.did";
 
 const FIVE_MINUTES_IN_MSEC = 5 * 60 * 1000;
+const DELAY = 250;
 
+/**
+ * Interface defining the parameters required to create an ICRC Ledger Actor.
+ */
 export interface IcrcActorParams {
+    /** The address of the ICRC Ledger canister. */
     assetAddress: string;
+    /** The HTTP agent used for communication with the Dfinity network. */
     agent: HttpAgent;
-};
+}
 
+/**
+ * Creates a new ICRC Ledger Actor instance.
+ * 
+ * This function takes an `IcrcActorParams` object containing the asset address and the HTTP agent
+ * and returns a new `LedgerActor` instance. The function uses the provided agent and canister ID to
+ * create the actor and configures a polling strategy that combines conditional delay, backoff, and timeout.
+ *
+ * @param params - An object containing the asset address and the HTTP agent.
+ * @returns A new `LedgerActor` instance.
+ */
 export function getIcrcActor(params: IcrcActorParams): LedgerActor {
     const { assetAddress, agent } = params;
     const canisterId = Principal.fromText(assetAddress);
     const ledgerActor = Actor.createActor<LedgerActor>(LedgerFactory, {
         agent,
         canisterId,
-        pollingStrategyFactory: () => chain(conditionalDelay(once(), 250), backoff(0, 0), timeout(FIVE_MINUTES_IN_MSEC)),
+        pollingStrategyFactory: () => chain(conditionalDelay(once(), DELAY), backoff(0, 0), timeout(FIVE_MINUTES_IN_MSEC)),
     });
     return ledgerActor;
-};
+}

--- a/frontend/pages/home/helpers/icrc/getIcrcActor.ts
+++ b/frontend/pages/home/helpers/icrc/getIcrcActor.ts
@@ -1,0 +1,24 @@
+import { Actor, HttpAgent } from "@dfinity/agent";
+import { backoff, chain, conditionalDelay, once, timeout } from "@dfinity/agent/lib/cjs/polling/strategy";
+import { Principal } from "@dfinity/principal";
+//
+import { _SERVICE as LedgerActor } from "@candid/icrcLedger/icrcLedgerService";
+import { idlFactory as LedgerFactory } from "@candid/icrcLedger/icrcLedgerCandid.did";
+
+const FIVE_MINUTES_IN_MSEC = 5 * 60 * 1000;
+
+export interface IcrcActorParams {
+    assetAddress: string;
+    agent: HttpAgent;
+};
+
+export function getIcrcActor(params: IcrcActorParams): LedgerActor {
+    const { assetAddress, agent } = params;
+    const canisterId = Principal.fromText(assetAddress);
+    const ledgerActor = Actor.createActor<LedgerActor>(LedgerFactory, {
+        agent,
+        canisterId,
+        pollingStrategyFactory: () => chain(conditionalDelay(once(), 250), backoff(0, 0), timeout(FIVE_MINUTES_IN_MSEC)),
+    });
+    return ledgerActor;
+};

--- a/frontend/pages/home/helpers/icrc/getIcrcActor.ts
+++ b/frontend/pages/home/helpers/icrc/getIcrcActor.ts
@@ -12,10 +12,10 @@ const DELAY = 250;
  * Interface defining the parameters required to create an ICRC Ledger Actor.
  */
 export interface IcrcActorParams {
-    /** The address of the ICRC Ledger canister. */
-    assetAddress: string;
-    /** The HTTP agent used for communication with the Dfinity network. */
-    agent: HttpAgent;
+  /** The address of the ICRC Ledger canister. */
+  assetAddress: string;
+  /** The HTTP agent used for communication with the Dfinity network. */
+  agent: HttpAgent;
 }
 
 /**
@@ -29,12 +29,12 @@ export interface IcrcActorParams {
  * @returns A new `LedgerActor` instance.
  */
 export function getIcrcActor(params: IcrcActorParams): LedgerActor {
-    const { assetAddress, agent } = params;
-    const canisterId = Principal.fromText(assetAddress);
-    const ledgerActor = Actor.createActor<LedgerActor>(LedgerFactory, {
-        agent,
-        canisterId,
-        pollingStrategyFactory: () => chain(conditionalDelay(once(), DELAY), backoff(0, 0), timeout(FIVE_MINUTES_IN_MSEC)),
-    });
-    return ledgerActor;
+  const { assetAddress, agent } = params;
+  const canisterId = Principal.fromText(assetAddress);
+  const ledgerActor = Actor.createActor<LedgerActor>(LedgerFactory, {
+      agent,
+      canisterId,
+      pollingStrategyFactory: () => chain(conditionalDelay(once(), DELAY), backoff(0, 0), timeout(FIVE_MINUTES_IN_MSEC)),
+  });
+  return ledgerActor;
 }

--- a/frontend/pages/home/helpers/icrc/getIcrcCanister.ts
+++ b/frontend/pages/home/helpers/icrc/getIcrcCanister.ts
@@ -19,3 +19,5 @@ export function getCanister(assetAddress: string | Principal): IcrcLedgerCaniste
         canisterId,
     });
 }
+
+

--- a/frontend/pages/home/helpers/icrc/getIcrcCanister.ts
+++ b/frontend/pages/home/helpers/icrc/getIcrcCanister.ts
@@ -1,4 +1,4 @@
-import { IcrcLedgerCanister } from "@dfinity/ledger";
+import { IcrcLedgerCanister } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
 import store from "@redux/Store";
 

--- a/frontend/pages/home/helpers/icrc/icrcAllowance.ts
+++ b/frontend/pages/home/helpers/icrc/icrcAllowance.ts
@@ -8,7 +8,7 @@ import { AssetContact } from "@redux/models/ContactsModels";
 import { _SERVICE as LedgerActor } from "@candid/icrcLedger/icrcLedgerService";
 import { idlFactory as LedgerFactory } from "@candid/icrcLedger/icrcLedgerCandid.did";
 import dayjs from "dayjs";
-import { ApproveParams } from "@dfinity/ledger";
+import { ApproveParams } from "@dfinity/ledger-icrc";
 import { getCanister } from "./getIcrcCanister";
 import { TAllowance } from "@/@types/allowance";
 

--- a/frontend/pages/home/helpers/icrc/icrcAllowance.ts
+++ b/frontend/pages/home/helpers/icrc/icrcAllowance.ts
@@ -73,6 +73,7 @@ export async function submitAllowanceApproval(
     }
 }
 
+// TODO: IcrcLedgerCanister.allowance from @dfinity/ledger-icrc perform call instead of query to get the allowance, remove this function once the issue is resolved in the ledger-icrc package
 export async function getAllowanceDetails(params: CheckAllowanceParams) {
     try {
         const { spenderPrincipal, spenderSubaccount, accountPrincipal, assetAddress, assetDecimal } = params;

--- a/frontend/pages/home/helpers/icrc/index.ts
+++ b/frontend/pages/home/helpers/icrc/index.ts
@@ -1,5 +1,6 @@
 export { getICRCSupportedStandards } from "./getICRCSupportedStandards";
 export { getCanister } from "./getIcrcCanister";
+export { getIcrcActor } from "./getIcrcActor";
 
 export {
     createApproveAllowanceParams,

--- a/frontend/pages/home/helpers/icrc/transactions.ts
+++ b/frontend/pages/home/helpers/icrc/transactions.ts
@@ -1,7 +1,7 @@
+import { getIcrcActor } from "./getIcrcActor";
 import { GetBalanceParams, TransactionFeeParams, TransferFromAllowanceParams, TransferTokensParams } from "@/@types/icrc";
 import { getCanister } from "./getIcrcCanister";
-import { getIcrcActor } from "./getIcrcActor";
-import { hexToUint8Array, toFullDecimal, toHoleBigInt } from "@/utils";
+import { hexToUint8Array, hexadecimalToUint8Array, toFullDecimal, toHoleBigInt } from "@/utils";
 import { Principal } from "@dfinity/principal";
 import { TransferFromParams } from "@dfinity/ledger-icrc";
 import store from "@redux/Store";
@@ -23,7 +23,7 @@ export async function transferTokens(params: TransferTokensParams) {
     const amount = toHoleBigInt(transferAmount, Number(decimal));
     const agent = store.getState().auth.userAgent;
 
-    const ledgerActor = await getIcrcActor({
+    const ledgerActor = getIcrcActor({
         agent,
         assetAddress,
     })
@@ -34,7 +34,10 @@ export async function transferTokens(params: TransferTokensParams) {
             subaccount: [hexToUint8Array(toSubAccount)],
         },
         amount,
-        from_subaccount: hexToUint8Array(fromSubAccount),
+        from_subaccount: hexadecimalToUint8Array(fromSubAccount),
+        fee: [],
+        memo: [],
+        created_at_time: [],
     });
 }
 

--- a/frontend/pages/home/helpers/icrc/transactions.ts
+++ b/frontend/pages/home/helpers/icrc/transactions.ts
@@ -4,6 +4,7 @@ import { hexToUint8Array, toFullDecimal, toHoleBigInt } from "@/utils";
 import { Principal } from "@dfinity/principal";
 import { TransferFromParams } from "@dfinity/ledger-icrc";
 import store from "@redux/Store";
+import { getIcrcActor } from "./getICRCSupportedStandards";
 
 export async function getTransactionFeeFromLedger(params: TransactionFeeParams) {
     try {
@@ -21,8 +22,14 @@ export async function transferTokens(params: TransferTokensParams) {
     const { receiverPrincipal, transferAmount, assetAddress, decimal, fromSubAccount, toSubAccount } = params;
     const canister = getCanister(assetAddress);
     const amount = toHoleBigInt(transferAmount, Number(decimal));
+    const agent = store.getState().auth.userAgent;
 
-    await canister.transfer({
+    const ledgerActor = await getIcrcActor({
+        agent,
+        assetAddress,
+    })
+
+    await ledgerActor.icrc1_transfer({
         to: {
             owner: Principal.fromText(receiverPrincipal),
             subaccount: [hexToUint8Array(toSubAccount)],

--- a/frontend/pages/home/helpers/icrc/transactions.ts
+++ b/frontend/pages/home/helpers/icrc/transactions.ts
@@ -1,4 +1,4 @@
-import { getIcrcActor } from "./getIcrcActor";
+import { getIcrcActor } from "@/pages/home/helpers/icrc";
 import { GetBalanceParams, TransactionFeeParams, TransferFromAllowanceParams, TransferTokensParams } from "@/@types/icrc";
 import { getCanister } from "./getIcrcCanister";
 import { hexToUint8Array, hexadecimalToUint8Array, toFullDecimal, toHoleBigInt } from "@/utils";

--- a/frontend/pages/home/helpers/icrc/transactions.ts
+++ b/frontend/pages/home/helpers/icrc/transactions.ts
@@ -1,10 +1,10 @@
 import { GetBalanceParams, TransactionFeeParams, TransferFromAllowanceParams, TransferTokensParams } from "@/@types/icrc";
 import { getCanister } from "./getIcrcCanister";
+import { getIcrcActor } from "./getIcrcActor";
 import { hexToUint8Array, toFullDecimal, toHoleBigInt } from "@/utils";
 import { Principal } from "@dfinity/principal";
 import { TransferFromParams } from "@dfinity/ledger-icrc";
 import store from "@redux/Store";
-import { getIcrcActor } from "./getICRCSupportedStandards";
 
 export async function getTransactionFeeFromLedger(params: TransactionFeeParams) {
     try {
@@ -20,7 +20,6 @@ export async function getTransactionFeeFromLedger(params: TransactionFeeParams) 
 
 export async function transferTokens(params: TransferTokensParams) {
     const { receiverPrincipal, transferAmount, assetAddress, decimal, fromSubAccount, toSubAccount } = params;
-    const canister = getCanister(assetAddress);
     const amount = toHoleBigInt(transferAmount, Number(decimal));
     const agent = store.getState().auth.userAgent;
 

--- a/frontend/pages/home/helpers/icrc/transactions.ts
+++ b/frontend/pages/home/helpers/icrc/transactions.ts
@@ -2,7 +2,7 @@ import { GetBalanceParams, TransactionFeeParams, TransferFromAllowanceParams, Tr
 import { getCanister } from "./getIcrcCanister";
 import { hexToUint8Array, toFullDecimal, toHoleBigInt } from "@/utils";
 import { Principal } from "@dfinity/principal";
-import { TransferFromParams } from "@dfinity/ledger";
+import { TransferFromParams } from "@dfinity/ledger-icrc";
 import store from "@redux/Store";
 
 export async function getTransactionFeeFromLedger(params: TransactionFeeParams) {

--- a/frontend/pages/home/hooks/useAllowanceTable.tsx
+++ b/frontend/pages/home/hooks/useAllowanceTable.tsx
@@ -3,7 +3,7 @@ import { formatDateTime } from "@/utils/formatTime";
 import { middleTruncation, toTitleCase } from "@/utils/strings";
 import { createColumnHelper } from "@tanstack/react-table";
 import { TAllowance, AllowancesTableColumnsEnum } from "@/@types/allowance";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import { isDateExpired } from "@/utils/time";
 import { useTranslation } from "react-i18next";
 import ActionCard from "../components/ICRC/allowance/ActionCard";

--- a/frontend/pages/login/components/MnemonicInput.tsx
+++ b/frontend/pages/login/components/MnemonicInput.tsx
@@ -1,7 +1,7 @@
+import { clsx } from "clsx";
 import { ReactComponent as CheckIcon } from "@assets/svg/files/edit-check.svg";
 import { CustomInput } from "@components/Input";
 import { handleMnemonicAuthenticated } from "@redux/CheckAuth";
-import clsx from "clsx";
 import { ChangeEvent, Dispatch, SetStateAction, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import * as bip39 from "bip39";

--- a/frontend/pages/login/components/SeedInput.tsx
+++ b/frontend/pages/login/components/SeedInput.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent, Dispatch, SetStateAction } from "react";
 import { ReactComponent as CheckIcon } from "@assets/svg/files/edit-check.svg";
 import { CustomInput } from "@components/Input";
 import { handleSeedAuthenticated } from "@redux/CheckAuth";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import { useTranslation } from "react-i18next";
 
 interface SeedMethodInputProps {

--- a/frontend/pages/login/components/WatchOnlyInput.tsx
+++ b/frontend/pages/login/components/WatchOnlyInput.tsx
@@ -3,7 +3,7 @@ import { ReactComponent as CheckIcon } from "@assets/svg/files/edit-check.svg";
 import { CustomInput } from "@components/Input";
 import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { handlePrincipalAuthenticated } from "@redux/CheckAuth";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import { ChangeEvent, Dispatch, SetStateAction, useState } from "react";
 
 interface WatchOnlyInputProps {

--- a/frontend/pages/login/components/WatchOnlyInput.tsx
+++ b/frontend/pages/login/components/WatchOnlyInput.tsx
@@ -1,7 +1,7 @@
 import { ReactComponent as CheckIcon } from "@assets/svg/files/edit-check.svg";
 //
 import { CustomInput } from "@components/Input";
-import { decodeIcrcAccount } from "@dfinity/ledger";
+import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { handlePrincipalAuthenticated } from "@redux/CheckAuth";
 import clsx from "clsx";
 import { ChangeEvent, Dispatch, SetStateAction, useState } from "react";

--- a/frontend/redux/assets/AssetActions.tsx
+++ b/frontend/redux/assets/AssetActions.tsx
@@ -1,7 +1,7 @@
 import { HttpAgent } from "@dfinity/agent";
 import store from "@redux/Store";
 import { SnsToken, Token, TokenMarketInfo, TokenSubAccount } from "@redux/models/TokenModels";
-import { IcrcAccount, IcrcIndexCanister, IcrcLedgerCanister, IcrcTokenMetadataResponse } from "@dfinity/ledger";
+import { IcrcAccount, IcrcIndexCanister, IcrcLedgerCanister, IcrcTokenMetadataResponse } from "@dfinity/ledger-icrc";
 import {
   formatIcpTransaccion,
   getSubAccountArray,

--- a/frontend/utils.ts
+++ b/frontend/utils.ts
@@ -10,7 +10,7 @@ import {
   IcrcTokenMetadataResponse,
   IcrcAccount,
   encodeIcrcAccount,
-} from "@dfinity/ledger";
+} from "@dfinity/ledger-icrc";
 import {
   OperationStatusEnum,
   OperationTypeEnum,
@@ -18,7 +18,8 @@ import {
   TransactionType,
   SpecialTxTypeEnum,
 } from "./const";
-import { Account, Transaction as T } from "@dfinity/ledger/dist/candid/icrc1_index";
+import { Account, Transaction as IcrcTransaction } from "@dfinity/ledger-icrc/dist/candid/icrc_index";
+// import { Account, Transaction as IcrcTransaction } from "@dfinity/ledger/dist/candid/icrc1_index";
 import { isNullish, uint8ArrayToHexString, bigEndianCrc32, encodeBase32 } from "@dfinity/utils";
 import { AccountIdentifier, SubAccount as SubAccountNNS } from "@dfinity/ledger-icp";
 
@@ -337,7 +338,7 @@ export const formatIcpTransaccion = (
 };
 
 export const formatckBTCTransaccion = (
-  ckBTCTransaction: T,
+  ckBTCTransaction: IcrcTransaction,
   id: bigint,
   principal: string,
   symbol: string,
@@ -348,8 +349,12 @@ export const formatckBTCTransaccion = (
   const trans = { status: OperationStatusEnum.Enum.COMPLETED, kind: kind } as Transaction;
   // Check Tx type ["transfer", "mint", "burn"]
   if (kind === SpecialTxTypeEnum.Enum.mint)
+    /**
+     * INFO: memo type modified from [] | [Uint8Array] to [] | [Uint8Array | number[]] on ledger-icrc
+     * Reference: https://github.com/dfinity/ic-js/blob/bf808fef5e3dbe4c3662abe8b350a04ba684619d/packages/ledger-icrc/candid/icrc_ledger.d.ts#L148
+     */
     mint.forEach(
-      (operation: { to: Account; memo: [] | [Uint8Array]; created_at_time: [] | [bigint]; amount: bigint }) => {
+      (operation: { to: Account; memo: [] | [Uint8Array | number[]]; created_at_time: [] | [bigint]; amount: bigint }) => {
         // Get Tx data from Mint record
         const value = operation.amount;
         const amount = value.toString();
@@ -381,7 +386,11 @@ export const formatckBTCTransaccion = (
   else if (kind === SpecialTxTypeEnum.Enum.burn)
     burn.forEach(
       // Get Tx data from Burn record
-      (operation: { from: Account; memo: [] | [Uint8Array]; created_at_time: [] | [bigint]; amount: bigint }) => {
+      /**
+       * INFO: memo type modified from [] | [Uint8Array] to [] | [Uint8Array | number[]] on ledger-icrc
+       * Reference: https://github.com/dfinity/ic-js/blob/bf808fef5e3dbe4c3662abe8b350a04ba684619d/packages/ledger-icrc/candid/icrc_ledger.d.ts#L148
+       */
+      (operation: { from: Account; memo: [] | [Uint8Array | number[]]; created_at_time: [] | [bigint]; amount: bigint }) => {
         const value = operation.amount;
         const amount = value.toString();
         trans.from = (operation.from.owner as Principal).toString();

--- a/frontend/utils.ts
+++ b/frontend/utils.ts
@@ -19,10 +19,8 @@ import {
   SpecialTxTypeEnum,
 } from "./const";
 import { Account, Transaction as IcrcTransaction } from "@dfinity/ledger-icrc/dist/candid/icrc_index";
-// import { Account, Transaction as IcrcTransaction } from "@dfinity/ledger/dist/candid/icrc1_index";
 import { isNullish, uint8ArrayToHexString, bigEndianCrc32, encodeBase32 } from "@dfinity/utils";
 import { AccountIdentifier, SubAccount as SubAccountNNS } from "@dfinity/ledger-icp";
-import { Subaccount as ICRCSubAcount } from "@dfinity/ledger-icrc/dist/candid/icrc_ledger";
 
 export const MILI_PER_SECOND = 1000000;
 

--- a/frontend/utils.ts
+++ b/frontend/utils.ts
@@ -22,6 +22,7 @@ import { Account, Transaction as IcrcTransaction } from "@dfinity/ledger-icrc/di
 // import { Account, Transaction as IcrcTransaction } from "@dfinity/ledger/dist/candid/icrc1_index";
 import { isNullish, uint8ArrayToHexString, bigEndianCrc32, encodeBase32 } from "@dfinity/utils";
 import { AccountIdentifier, SubAccount as SubAccountNNS } from "@dfinity/ledger-icp";
+import { Subaccount as ICRCSubAcount } from "@dfinity/ledger-icrc/dist/candid/icrc_ledger";
 
 export const MILI_PER_SECOND = 1000000;
 
@@ -210,7 +211,12 @@ export const hexToUint8Array = (hex: string) => {
   } else return new Uint8Array(32);
 };
 
-export const subUint8ArrayToHex = (sub: Uint8Array | undefined) => {
+/**
+ * INFO: Uint8Array | number[]; was added, Unit8Array was removed from @dfinity/ledger-icrc. Remove when @dfinity/ledger will be replaced by @dfinity/ledger-icrc entirely on HPL.
+ * Reference: https://github.com/dfinity/ic-js/blob/bf808fef5e3dbe4c3662abe8b350a04ba684619d/packages/ledger-icrc/candid/icrc_ledger.d.ts#L161
+ * TODO: confirm no breaking changes on @dfinity/ledger-icrc adding
+ */
+export const subUint8ArrayToHex = (sub: Uint8Array | number[] | undefined) => {
   if (sub) {
     const hex = removeLeadingZeros(Buffer.from(sub).toString("hex"));
     if (hex === "") return "0";

--- a/frontend/utils.ts
+++ b/frontend/utils.ts
@@ -209,6 +209,11 @@ export const hexToUint8Array = (hex: string) => {
   } else return new Uint8Array(32);
 };
 
+export const hexadecimalToUint8Array = (hexadecimalSubAccount: string): [] | [Uint8Array | number[]] => {
+  if (hexadecimalSubAccount.length === 0) return [];
+  else return [hexToUint8Array(hexadecimalSubAccount)];
+};
+
 /**
  * INFO: Uint8Array | number[]; was added, Unit8Array was removed from @dfinity/ledger-icrc. Remove when @dfinity/ledger will be replaced by @dfinity/ledger-icrc entirely on HPL.
  * Reference: https://github.com/dfinity/ic-js/blob/bf808fef5e3dbe4c3662abe8b350a04ba684619d/packages/ledger-icrc/candid/icrc_ledger.d.ts#L161

--- a/frontend/utils.ts
+++ b/frontend/utils.ts
@@ -355,7 +355,9 @@ export const formatckBTCTransaccion = (
   if (kind === SpecialTxTypeEnum.Enum.mint)
     /**
      * INFO: memo type modified from [] | [Uint8Array] to [] | [Uint8Array | number[]] on ledger-icrc
-     * Reference: https://github.com/dfinity/ic-js/blob/bf808fef5e3dbe4c3662abe8b350a04ba684619d/packages/ledger-icrc/candid/icrc_ledger.d.ts#L148
+     * References:
+     * - https://forum.dfinity.org/t/breaking-changes-in-ledger-icrc-icp-javascript-libraries/23465
+     * - https://github.com/dfinity/ic-js/blob/bf808fef5e3dbe4c3662abe8b350a04ba684619d/packages/ledger-icrc/candid/icrc_ledger.d.ts#L148
      */
     mint.forEach(
       (operation: { to: Account; memo: [] | [Uint8Array | number[]]; created_at_time: [] | [bigint]; amount: bigint }) => {
@@ -392,7 +394,9 @@ export const formatckBTCTransaccion = (
       // Get Tx data from Burn record
       /**
        * INFO: memo type modified from [] | [Uint8Array] to [] | [Uint8Array | number[]] on ledger-icrc
-       * Reference: https://github.com/dfinity/ic-js/blob/bf808fef5e3dbe4c3662abe8b350a04ba684619d/packages/ledger-icrc/candid/icrc_ledger.d.ts#L148
+       * References:
+       * - https://forum.dfinity.org/t/breaking-changes-in-ledger-icrc-icp-javascript-libraries/23465
+       * - https://github.com/dfinity/ic-js/blob/bf808fef5e3dbe4c3662abe8b350a04ba684619d/packages/ledger-icrc/candid/icrc_ledger.d.ts#L148
        */
       (operation: { from: Account; memo: [] | [Uint8Array | number[]]; created_at_time: [] | [bigint]; amount: bigint }) => {
         const value = operation.amount;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@dfinity/identity-secp256k1": "^1.0.1",
         "@dfinity/ledger": "^1.0.0-next-2023-10-02.1",
         "@dfinity/ledger-icp": "^2.2.1",
+        "@dfinity/ledger-icrc": "^2.2.0",
         "@dfinity/principal": "^1.0.1",
         "@dfinity/utils": "^2.1.2",
         "@emotion/styled": "^11.11.0",
@@ -808,6 +809,17 @@
         "@dfinity/agent": "^1.0.1",
         "@dfinity/candid": "^1.0.1",
         "@dfinity/nns-proto": "^1.0.1",
+        "@dfinity/principal": "^1.0.1",
+        "@dfinity/utils": "^2.1.2"
+      }
+    },
+    "node_modules/@dfinity/ledger-icrc": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.0.tgz",
+      "integrity": "sha512-Le17WLCotBsREWzB29Vm6ApYsmYfe7qQl6GmS0WW6vIMfL+ddBffLfDkzbCraM0ok4PVI/3jxt3TRwBNirvxTQ==",
+      "peerDependencies": {
+        "@dfinity/agent": "^1.0.1",
+        "@dfinity/candid": "^1.0.1",
         "@dfinity/principal": "^1.0.1",
         "@dfinity/utils": "^2.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@dfinity/identity-secp256k1": "^1.0.1",
     "@dfinity/ledger": "^1.0.0-next-2023-10-02.1",
     "@dfinity/ledger-icp": "^2.2.1",
+    "@dfinity/ledger-icrc": "^2.2.0",
     "@dfinity/principal": "^1.0.1",
     "@dfinity/utils": "^2.1.2",
     "@emotion/styled": "^11.11.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "lint": "eslint . --ext .ts,.tsx",
+    "lint:fix": "eslint . --ext .ts,.tsx --fix",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "@builder.io/partytown": "^0.8.0",


### PR DESCRIPTION
## Overview

This pr aims to improve the latency of ICRC-1 transfers by optimizing the polling mechanism currently used.

The current implementation likely utilizes a polling interval of 1 second with an exponential backoff factor of 1.2 applied on retries.

This pr reduce the polling interval to a fixed value of 250 milliseconds and eliminate the exponential backoff mechanism.

## Additional notes

Due to deprecation, an internal library was replaced with a new one  `dfinity/ledger` -> `@dfinity/ledger-icrc`. To avoid compatibility issues with HPL, the older library was not immediately removed from dependencies. This will be addressed in a future update. The changes are minor and shouldn't cause significant disruptions.

Reference:  [Breaking Changes in Ledger ICRC/ICP JavaScript Libraries](https://forum.dfinity.org/t/breaking-changes-in-ledger-icrc-icp-javascript-libraries/23465)
